### PR TITLE
Pin cadence web image to v3.35.6 until port forwarding issue is addressed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,4 +75,7 @@ cadencechart/README.md file should be updated.
 
 ## Publish chart
 
+After making changes to templates, increment the chart version in charts/cadence/Chart.yaml.
+Then merge your changes and automation will take care of publishing the new version.
 Cadence chart is hosted on github pages and automation is done using [Chart Releaser Action](https://helm.sh/docs/howto/chart_releaser_action/).
+After new version is available in helm repo, deploy it to a K8s cluster to validate.

--- a/charts/cadence/templates/cadence-web-deployment.yaml
+++ b/charts/cadence/templates/cadence-web-deployment.yaml
@@ -22,8 +22,8 @@ spec:
         ports:
         - containerPort: 8088
         env:
-        - name: CADENCE_TCHANNEL_PEERS
-          value: cadence-frontend.{{ .Release.Namespace }}.svc.cluster.local:{{ $.Values.frontend.port }}
+        - name: CADENCE_GRPC_PEERS
+          value: cadence-frontend.{{ .Release.Namespace }}.svc.cluster.local:{{ $.Values.frontend.grpcPort }}
         resources:
           limits:
             cpu: {{ $.Values.web.cpu.limit }}


### PR DESCRIPTION
**Changes:**
Helm chart was defaulting to web:latest image but it stopped working for port-forwarding scenarios since v3.35.6. 
Pinning v3.35.6 until the underlying issue is fixed. 
Something must have changed in the way the web service is started in > v3.35.6 which prevents localhost:8088 port forwarding.

**Testing:**
Followed steps in CONTRIBUTING.md.