### PR TITLE
set default cadence version to v1.2.6

### DIFF
--- a/charts/cadence/values.yaml
+++ b/charts/cadence/values.yaml
@@ -8,7 +8,7 @@ cassandra:
   endpoint: ""
   schema:
     # -- Cassandra schema version of the Cadence keyspace to use. Latest value can be found at https://github.com/uber/cadence/blob/master/schema/cassandra/version.go
-    version: 0.37
+    version: 0.40
     # -- Cassandra schema version of the Cadence visibility keyspace to use. Latest value can be found at https://github.com/uber/cadence/blob/master/schema/cassandra/version.go
     visibility_version: 0.9
   deployment:
@@ -39,7 +39,7 @@ frontend:
     # -- Docker image repository to use for the Cadence server
     repository: "docker.io/ubercadence/server"
     # -- Docker image tag to use for the Cadence server
-    tag: "master-auto-setup"
+    tag: "v1.2.16-auto-setup"
   cpu:
     limit: "500m"
     request: "500m"
@@ -58,7 +58,7 @@ matching:
     # -- Docker image repository to use for the Cadence server
     repository: "docker.io/ubercadence/server"
     # -- Docker image tag to use for the Cadence server
-    tag: "master-auto-setup"
+    tag: "v1.2.16-auto-setup"
   cpu:
     limit: "500m"
     request: "500m"
@@ -77,7 +77,7 @@ history:
     # -- Docker image repository to use for the Cadence server
     repository: "docker.io/ubercadence/server"
     # -- Docker image tag to use for the Cadence server
-    tag: "master-auto-setup"
+    tag: "v1.2.16-auto-setup"
   cpu:
     limit: "500m"
     request: "500m"
@@ -94,7 +94,7 @@ worker:
     # -- Docker image repository to use for the Cadence server
     repository: "docker.io/ubercadence/server"
     # -- Docker image tag to use for the Cadence server
-    tag: "master-auto-setup"
+    tag: "v1.2.16-auto-setup"
   cpu:
     limit: "500m"
     request: "500m"


### PR DESCRIPTION
**Why**
Install would fail on master-auto-setup version because schema version changes. This is a temporary solution before we find a better way for schema-upgrade job. 