### PR TITLE
support schema upgrade

### DIFF
--- a/charts/cadence/Chart.yaml
+++ b/charts/cadence/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cadence/templates/schema-job.yaml
+++ b/charts/cadence/templates/schema-job.yaml
@@ -9,6 +9,8 @@ spec:
   template:
     metadata:
       name: cadence-schema-setup
+      annotations:
+        schemaVersion: "{{ .Values.cassandra.schema.version }}"
     spec:
       restartPolicy: "OnFailure"
       initContainers:

--- a/charts/cadence/templates/schema-job.yaml
+++ b/charts/cadence/templates/schema-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cadence-schema-setup
+  name: cadence-schema-setup-v{{ .Values.cassandra.schema.version | replace "." "-" }}
   labels:
     {{- include "cadence.commonlabels" . | nindent 4 }}
 spec:
@@ -9,8 +9,6 @@ spec:
   template:
     metadata:
       name: cadence-schema-setup
-      annotations:
-        schemaVersion: "{{ .Values.cassandra.schema.version }}"
     spec:
       restartPolicy: "OnFailure"
       initContainers:

--- a/charts/cadence/values.yaml
+++ b/charts/cadence/values.yaml
@@ -8,7 +8,7 @@ cassandra:
   endpoint: ""
   schema:
     # -- Cassandra schema version of the Cadence keyspace to use. Latest value can be found at https://github.com/uber/cadence/blob/master/schema/cassandra/version.go
-    version: 0.37
+    version: 0.40
     # -- Cassandra schema version of the Cadence visibility keyspace to use. Latest value can be found at https://github.com/uber/cadence/blob/master/schema/cassandra/version.go
     visibility_version: 0.9
   deployment:
@@ -39,7 +39,7 @@ frontend:
     # -- Docker image repository to use for the Cadence server
     repository: "docker.io/ubercadence/server"
     # -- Docker image tag to use for the Cadence server
-    tag: "master-auto-setup"
+    tag: "v1.2.16-auto-setup"
   cpu:
     limit: "500m"
     request: "500m"
@@ -58,7 +58,7 @@ matching:
     # -- Docker image repository to use for the Cadence server
     repository: "docker.io/ubercadence/server"
     # -- Docker image tag to use for the Cadence server
-    tag: "master-auto-setup"
+    tag: "v1.2.16-auto-setup"
   cpu:
     limit: "500m"
     request: "500m"
@@ -77,7 +77,7 @@ history:
     # -- Docker image repository to use for the Cadence server
     repository: "docker.io/ubercadence/server"
     # -- Docker image tag to use for the Cadence server
-    tag: "master-auto-setup"
+    tag: "v1.2.16-auto-setup"
   cpu:
     limit: "500m"
     request: "500m"
@@ -94,7 +94,7 @@ worker:
     # -- Docker image repository to use for the Cadence server
     repository: "docker.io/ubercadence/server"
     # -- Docker image tag to use for the Cadence server
-    tag: "master-auto-setup"
+    tag: "v1.2.16-auto-setup"
   cpu:
     limit: "500m"
     request: "500m"

--- a/charts/cadence/values.yaml
+++ b/charts/cadence/values.yaml
@@ -8,9 +8,9 @@ cassandra:
   endpoint: ""
   schema:
     # -- Cassandra schema version of the Cadence keyspace to use. Latest value can be found at https://github.com/uber/cadence/blob/master/schema/cassandra/version.go
-    version: 0.40
+    version: "0.40"
     # -- Cassandra schema version of the Cadence visibility keyspace to use. Latest value can be found at https://github.com/uber/cadence/blob/master/schema/cassandra/version.go
-    visibility_version: 0.9
+    visibility_version: "0.9"
   deployment:
     # -- When enabled, a single instance Cassandra will be deployed as part of the Helm chart
     # -- When disabled, the Cassandra deployment is expected to be provided externally. For production use cases, it is recommended to use an external Cassandra deployment.


### PR DESCRIPTION
**Why**

Existing schema-job only runs once. It means that version upgrade won't work if there is a schema change. To support it, we can put version name into the schema-job so k8s cluster would create a new job that upgrades the schema. 

**Changes**

add version into schema job name. 

**Test**

Tested in GCP 

<img width="825" alt="Screenshot 2025-02-24 at 9 50 48 AM" src="https://github.com/user-attachments/assets/ef0797dc-42aa-4f3f-898e-973de65e6a59" />

Helm install
```
shengs@cadence-charts % kubectl exec  cassandra-deployment-6587bc76bd-chjsg -- cqlsh -k cadence -e 'select * from schema_version'

 keyspace_name | creation_time                   | curr_version | min_compatible_version
---------------+---------------------------------+--------------+------------------------
       cadence | 2025-02-24 17:35:16.679000+0000 |         0.40 |                   0.40

(1 rows)
```

After Helm upgrade
```
shengs@cadence-charts % kubectl exec  cassandra-deployment-6587bc76bd-chjsg -- cqlsh -k cadence -e 'select * from schema_version'

 keyspace_name | creation_time                   | curr_version | min_compatible_version
---------------+---------------------------------+--------------+------------------------
       cadence | 2025-02-24 17:49:59.772000+0000 |         0.41 |                   0.41

(1 rows)
```


