### PR TITLE
Update helm docs for v0.1.3 changes

### DIFF
--- a/charts/cadence/README.md
+++ b/charts/cadence/README.md
@@ -1,6 +1,6 @@
 # cadence
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 Cadence Helm chart for Kubernetes
 
@@ -16,14 +16,14 @@ Cadence Helm chart for Kubernetes
 | cassandra.deployment.memory.limit | string | `"1Gi"` |  |
 | cassandra.deployment.memory.request | string | `"1Gi"` |  |
 | cassandra.endpoint | string | `""` | External Cassandra endpoint to connect to. Required when cassandra.deployment.enabled is set to false |
-| cassandra.schema.version | float | `0.37` | Cassandra schema version of the Cadence keyspace to use. Latest value can be found at https://github.com/uber/cadence/blob/master/schema/cassandra/version.go |
-| cassandra.schema.visibility_version | float | `0.9` | Cassandra schema version of the Cadence visibility keyspace to use. Latest value can be found at https://github.com/uber/cadence/blob/master/schema/cassandra/version.go |
+| cassandra.schema.version | string | `"0.40"` | Cassandra schema version of the Cadence keyspace to use. Latest value can be found at https://github.com/uber/cadence/blob/master/schema/cassandra/version.go |
+| cassandra.schema.visibility_version | string | `"0.9"` | Cassandra schema version of the Cadence visibility keyspace to use. Latest value can be found at https://github.com/uber/cadence/blob/master/schema/cassandra/version.go |
 | dynamicConfig | object | `{"values":{"history.workflowIDExternalRateLimitEnabled":[{"value":true}]}}` | Dynamic config values to be set in the Cadence server. List of keys can be found at https://github.com/uber/cadence/blob/master/common/dynamicconfig/constants.go |
 | frontend.cpu.limit | string | `"500m"` |  |
 | frontend.cpu.request | string | `"500m"` |  |
 | frontend.grpcPort | int | `7833` | GRPC port of cadence frontend service. DO NOT CHANGE |
 | frontend.image.repository | string | `"docker.io/ubercadence/server"` | Docker image repository to use for the Cadence server |
-| frontend.image.tag | string | `"master-auto-setup"` | Docker image tag to use for the Cadence server |
+| frontend.image.tag | string | `"v1.2.16-auto-setup"` | Docker image tag to use for the Cadence server |
 | frontend.memory.limit | string | `"1Gi"` |  |
 | frontend.memory.request | string | `"1Gi"` |  |
 | frontend.port | int | `7933` | Tchannel port of cadence frontend service. DO NOT CHANGE |
@@ -32,7 +32,7 @@ Cadence Helm chart for Kubernetes
 | history.cpu.request | string | `"500m"` |  |
 | history.grpcPort | int | `7834` | GRPC port of cadence history service. DO NOT CHANGE |
 | history.image.repository | string | `"docker.io/ubercadence/server"` | Docker image repository to use for the Cadence server |
-| history.image.tag | string | `"master-auto-setup"` | Docker image tag to use for the Cadence server |
+| history.image.tag | string | `"v1.2.16-auto-setup"` | Docker image tag to use for the Cadence server |
 | history.memory.limit | string | `"1Gi"` |  |
 | history.memory.request | string | `"1Gi"` |  |
 | history.port | int | `7934` | Tchannel port of cadence history service. DO NOT CHANGE |
@@ -43,7 +43,7 @@ Cadence Helm chart for Kubernetes
 | matching.cpu.request | string | `"500m"` |  |
 | matching.grpcPort | int | `7835` | GRPC port of cadence matching service. DO NOT CHANGE |
 | matching.image.repository | string | `"docker.io/ubercadence/server"` | Docker image repository to use for the Cadence server |
-| matching.image.tag | string | `"master-auto-setup"` | Docker image tag to use for the Cadence server |
+| matching.image.tag | string | `"v1.2.16-auto-setup"` | Docker image tag to use for the Cadence server |
 | matching.memory.limit | string | `"1Gi"` |  |
 | matching.memory.request | string | `"1Gi"` |  |
 | matching.port | int | `7935` | Tchannel port of cadence matching service. DO NOT CHANGE |
@@ -51,14 +51,14 @@ Cadence Helm chart for Kubernetes
 | web.cpu.limit | string | `"500m"` |  |
 | web.cpu.request | string | `"500m"` |  |
 | web.image.repository | string | `"docker.io/ubercadence/web"` | Docker image repository to use for the Cadence Web UI |
-| web.image.tag | string | `"latest"` | Docker image tag to use for the Cadence Web UI |
+| web.image.tag | string | `"v3.35.6"` | Docker image tag to use for the Cadence Web UI |
 | web.memory.limit | string | `"1Gi"` |  |
 | web.memory.request | string | `"1Gi"` |  |
 | web.replicas | int | `1` |  |
 | worker.cpu.limit | string | `"500m"` |  |
 | worker.cpu.request | string | `"500m"` |  |
 | worker.image.repository | string | `"docker.io/ubercadence/server"` | Docker image repository to use for the Cadence server |
-| worker.image.tag | string | `"master-auto-setup"` | Docker image tag to use for the Cadence server |
+| worker.image.tag | string | `"v1.2.16-auto-setup"` | Docker image tag to use for the Cadence server |
 | worker.memory.limit | string | `"1Gi"` |  |
 | worker.memory.request | string | `"1Gi"` |  |
 | worker.port | int | `7939` | Tchannel port of cadence worker service. DO NOT CHANGE |


### PR DESCRIPTION
Updated auto-generated documentation by running `helm-docs` command. 