### PR TITLE
Switch from web UI v3 to v4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,59 +4,60 @@
 
 ```
 helm package ./charts/cadence
-helm template cadence-release cadence-0.1.3.tgz > template_out.yaml
+helm template cadence-release cadence-0.1.5.tgz > template_out.yaml
 ```
 
 ## Build and deploy to a k8s cluster
 
+1. Build helm package and deploy to a k8s cluster
 ```
 helm package ./charts/cadence
-helm upgrade --install cadence-release cadence-0.1.3.tgz \
+helm upgrade --install cadence-release cadence-0.1.5.tgz \
     -n cadencetest \
     --create-namespace
 ```
 
-Port forward to check the UI
+2. Port forward to check the UI
 ```
 kubectl port-forward svc/cadence-web-service 8088:8088 -n cadencetest
 ```
 
-Port forward frontend service to run CLI commands
+Visit localhost:8088 and validate it is accessible.
+
+3. Port forward frontend service to run CLI commands
 ```
-kubectl port-forward svc/cadence-frontend 7933:7933 -n cadencetest
+kubectl port-forward svc/cadence-frontend 7833:7833 -n cadencetest
 ```
 
-Register domain:
+4. Register a domain:
 ```
-cadence --address localhost:7933 \
-    --env development \
-    --domain samples-domain domain register
+cadence --env development \
+    --address localhost:7833 \
+    --transport grpc \
+    --domain samples-domain \
+    domain register \
+    --retention 1
 ```
 
-Run samples:
-1. Clone https://github.com/uber-common/cadence-samples
+5. Run samples:
+- Clone https://github.com/uber-common/cadence-samples
 
-2. Change host in config/development.yaml
+- Change host in config/development.yaml
 ```
 host: "localhost:7833"
 ```
 
-3. Port forward to frontend on 7833
-```
-kubectl port-forward svc/cadence-frontend-headless 7833:7833 -n cadencetest
-```
-
-4. Run sample worker (run at samples repo root)
+- Run sample worker (run at samples repo root)
 ```
 ./bin/helloworld -m worker
 ```
 
-5. Trigger a workflow  (run at samples repo root)
+- Trigger a workflow  (run at samples repo root)
 ```
 ./bin/helloworld -m trigger
 ```
 
-Visit localhost:8088 and validate the new workflow exists!
+6. Visit localhost:8088 and validate the new workflow exists!
 
 ## Generate helmdocs
 

--- a/charts/cadence/Chart.yaml
+++ b/charts/cadence/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cadence/README.md
+++ b/charts/cadence/README.md
@@ -1,6 +1,6 @@
 # cadence
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 Cadence Helm chart for Kubernetes
 
@@ -51,7 +51,7 @@ Cadence Helm chart for Kubernetes
 | web.cpu.limit | string | `"500m"` |  |
 | web.cpu.request | string | `"500m"` |  |
 | web.image.repository | string | `"docker.io/ubercadence/web"` | Docker image repository to use for the Cadence Web UI |
-| web.image.tag | string | `"v3.35.6"` | Docker image tag to use for the Cadence Web UI |
+| web.image.tag | string | `"v4.0.3"` | Docker image tag to use for the Cadence Web UI |
 | web.memory.limit | string | `"1Gi"` |  |
 | web.memory.request | string | `"1Gi"` |  |
 | web.replicas | int | `1` |  |

--- a/charts/cadence/templates/cadence-web-deployment.yaml
+++ b/charts/cadence/templates/cadence-web-deployment.yaml
@@ -22,12 +22,8 @@ spec:
         ports:
         - containerPort: 8088
         env:
-         - name: CADENCE_TCHANNEL_PEERS
-           value: cadence-frontend.{{ .Release.Namespace }}.svc.cluster.local:{{ $.Values.frontend.port }}
-        # TODO: Switch image version to v4.0.0 and uncomment below after the port forwarding issue is fixed
-        # Something must have changed in the way the web service is started in > v3.35.6 which prevents localhost:8088 port forwarding
-        # - name: CADENCE_GRPC_PEERS
-        #   value: cadence-frontend.{{ .Release.Namespace }}.svc.cluster.local:{{ $.Values.frontend.grpcPort }}
+        - name: CADENCE_GRPC_PEERS
+          value: cadence-frontend.{{ .Release.Namespace }}.svc.cluster.local:{{ $.Values.frontend.grpcPort }}
         resources:
           limits:
             cpu: {{ $.Values.web.cpu.limit }}

--- a/charts/cadence/values.yaml
+++ b/charts/cadence/values.yaml
@@ -108,7 +108,7 @@ web:
     # -- Docker image repository to use for the Cadence Web UI
     repository: "docker.io/ubercadence/web"
     # -- Docker image tag to use for the Cadence Web UI
-    tag: "v3.35.6"
+    tag: "v4.0.3"
   cpu:
     limit: "500m"
     request: "500m"


### PR DESCRIPTION
Changing helm chart default to install new version of web UI `ubercadence/web:v4.0.3`. 

Tested by following steps in CONTRIBUTING.md.