### PR TITLE
Added serviceMonitor

### DIFF
--- a/charts/cadence/Chart.yaml
+++ b/charts/cadence/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cadence/README.md
+++ b/charts/cadence/README.md
@@ -1,6 +1,6 @@
 # cadence
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 Cadence Helm chart for Kubernetes
 
@@ -48,6 +48,18 @@ Cadence Helm chart for Kubernetes
 | matching.memory.request | string | `"1Gi"` |  |
 | matching.port | int | `7935` | Tchannel port of cadence matching service. DO NOT CHANGE |
 | matching.replicas | int | `3` | Number of matching replicas to deploy |
+| metrics.enabled | bool | `true` |  |
+| metrics.port | int | `9090` |  |
+| metrics.portName | string | `"metrics"` |  |
+| metrics.serviceMonitor.additionalLabels | object | `{}` |  |
+| metrics.serviceMonitor.annotations | object | `{}` | Annotations to be added to the ServiceMonitor. |
+| metrics.serviceMonitor.enabled | bool | `false` |  |
+| metrics.serviceMonitor.metricRelabelings | list | `[]` |  |
+| metrics.serviceMonitor.namespace | string | `""` |  |
+| metrics.serviceMonitor.namespaceSelector | object | `{}` |  |
+| metrics.serviceMonitor.relabelings | list | `[]` |  |
+| metrics.serviceMonitor.scrapeInterval | string | `"15s"` |  |
+| metrics.serviceMonitor.targetLabels | list | `[]` |  |
 | web.cpu.limit | string | `"500m"` |  |
 | web.cpu.request | string | `"500m"` |  |
 | web.image.repository | string | `"docker.io/ubercadence/web"` | Docker image repository to use for the Cadence Web UI |

--- a/charts/cadence/templates/server-deployment.yaml
+++ b/charts/cadence/templates/server-deployment.yaml
@@ -47,9 +47,11 @@ spec:
             - name: rpc
               containerPort: {{ $serviceCfg.port }}
               protocol: TCP
-            - name: metrics
-              containerPort: 9090
+            {{- if $dot.Values.metrics.enabled }}
+            - name: {{ $dot.Values.metrics.portName }}
+              containerPort: {{ $dot.Values.metrics.port }}
               protocol: TCP
+            {{- end }}
              {{- if ne $service "worker" }}
             - name: grpc
               containerPort: {{ $serviceCfg.grpcPort }}

--- a/charts/cadence/templates/server-service.yaml
+++ b/charts/cadence/templates/server-service.yaml
@@ -46,10 +46,12 @@ spec:
       protocol: TCP
       port: {{ $serviceCfg.port }}
       targetPort: rpc
-    - name: metrics
+    {{- if $dot.Values.metrics.enabled }}
+    - name: {{ $dot.Values.metrics.portName }}
       protocol: TCP
-      port: 9090
-      targetPort: metrics
+      port: {{ $dot.Values.metrics.port }}
+      targetPort: {{ $dot.Values.metrics.portName }}
+    {{- end }}
     {{- if ne $service "worker" }}
     - name: grpc
       protocol: TCP

--- a/charts/cadence/templates/server-servicemonitor.yaml
+++ b/charts/cadence/templates/server-servicemonitor.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "cadence.name" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "cadence.commonlabels" . | nindent 4 }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml .Values.metrics.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.metrics.serviceMonitor.annotations }}
+  annotations: {{ toYaml .Values.metrics.serviceMonitor.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.metrics.serviceMonitor.namespaceSelector }}
+  namespaceSelector: {{ toYaml .Values.metrics.serviceMonitor.namespaceSelector | nindent 4 }}
+  {{- else }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "cadence.commonlabels" . | nindent 6 }}
+  endpoints:
+  - port: {{ .Values.metrics.portName }}
+    interval: {{ .Values.metrics.serviceMonitor.scrapeInterval }}
+    {{- if .Values.metrics.serviceMonitor.honorLabels }}
+    honorLabels: true
+    {{- end }}
+    {{- if .Values.metrics.serviceMonitor.relabelings }}
+    relabelings: {{ toYaml .Values.metrics.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+    {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{ toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
+  {{- if .Values.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel | quote }}
+  {{- end }}
+  {{- if .Values.metrics.serviceMonitor.targetLabels }}
+  targetLabels: {{ toYaml .Values.metrics.serviceMonitor.targetLabels | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/cadence/values.yaml
+++ b/charts/cadence/values.yaml
@@ -121,3 +121,27 @@ dynamicConfig:
   values:
     history.workflowIDExternalRateLimitEnabled:
       - value: true
+
+metrics:
+  enabled: true
+  port: 9090
+  portName: metrics
+
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
+    # -- Annotations to be added to the ServiceMonitor.
+    annotations: {}
+    ## The label to use to retrieve the job name from.
+    ## jobLabel: "app.kubernetes.io/name"
+    namespace: ""
+    namespaceSelector: {}
+    ## Default: scrape .Release.Namespace or namespaceOverride only
+    ## To scrape all, use the following:
+    ## namespaceSelector:
+    ##   any: true
+    scrapeInterval: 15s
+    # honorLabels: true
+    targetLabels: []
+    relabelings: []
+    metricRelabelings: []


### PR DESCRIPTION
# Add Prometheus Metrics Support and ServiceMonitor

## Overview
This PR adds comprehensive Prometheus metrics support to the Cadence Helm chart, including configurable metrics endpoints and ServiceMonitor for Prometheus Operator integration.
This will be usefull for use Grafana dashboards [https://github.com/cadence-workflow/cadence/tree/master/docker/grafana/provisioning/dashboards](https://github.com/cadence-workflow/cadence/tree/master/docker/grafana/provisioning/dashboards )

## Changes Made

### 📊 **Metrics Configuration**
- Added `metrics` section in `values.yaml` with configurable port, portName, and ServiceMonitor settings
- Metrics are enabled by default to maintain backward compatibility
- Port defaults to 9090 with configurable portName "metrics"

### 🔧 **Template Updates**

#### **Deployment Changes**
- Added conditional metrics port exposure in deployments based on `metrics.enabled` flag
- Added metrics port configuration to container spec when enabled
- Ensured proper port naming for ServiceMonitor discovery

#### **Service Changes**  
- Modified service templates to conditionally include metrics port
- Added proper port labeling for Prometheus scraping
- Maintained existing service functionality while adding metrics capability

#### **ServiceMonitor Resource**
- Added new `server-servicemonitor.yaml` template for Prometheus Operator integration
- Configurable namespace, labels, annotations, and scraping intervals
- Support for relabeling, metric relabeling, and target labels
- Conditional rendering based on both `metrics.enabled` and `metrics.serviceMonitor.enabled`

### ⚙️ **Configuration Options**
```yaml
metrics:
  enabled: false                    # Enable/disable metrics globally
  port: 9090                       # Metrics port
  portName: metrics                # Port name for service discovery
  
  serviceMonitor:
    enabled: false                 # Enable ServiceMonitor creation
    additionalLabels: {}           # Additional labels for ServiceMonitor
    annotations: {}                # ServiceMonitor annotations  
    namespace: ""                  # ServiceMonitor namespace (defaults to release namespace)
    namespaceSelector: {}          # Namespace selector for scraping
    scrapeInterval: 15s            # Prometheus scrape interval
    honorLabels: false             # Honor labels from metrics endpoint
    jobLabel: ""                   # Job label for Prometheus
    targetLabels: []               # Target labels to add to metrics
    relabelings: []                # Relabeling configurations
    metricRelabelings: []          # Metric relabeling configurations
```

## Testing
- [x] Helm template validation passes
- [x] Default values maintain backward compatibility  
- [x] ServiceMonitor renders correctly when enabled
- [x] Metrics ports are properly exposed in services and deployments
- [x] Chart installs successfully with both metrics enabled/disabled
![image](https://github.com/user-attachments/assets/47c13a69-cab2-41a2-902e-9954534bb0b0)
![image](https://github.com/user-attachments/assets/52f03b78-df42-48c2-b7b6-f2007e4f1972)
![image](https://github.com/user-attachments/assets/0ab057f8-901c-4ee3-912a-e8639f91127b)
![image](https://github.com/user-attachments/assets/4ba11502-9b1b-4089-b8d8-59e04be4ce69)
