### PR TITLE
fix: pg_isready sslmode use

### DIFF
--- a/charts/cadence/Chart.yaml
+++ b/charts/cadence/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cadence
-version: 1.1.0
+version: 1.1.1
 appVersion: v1.3.6
 
 description: |

--- a/charts/cadence/README.md
+++ b/charts/cadence/README.md
@@ -1,6 +1,6 @@
 # cadence
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.6](https://img.shields.io/badge/AppVersion-v1.3.6-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.6](https://img.shields.io/badge/AppVersion-v1.3.6-informational?style=flat-square)
 
 Cadence is a distributed, scalable, durable, and highly available orchestration engine
 to execute asynchronous long-running business logic in a scalable and resilient way.

--- a/charts/cadence/templates/server-deployment.yaml
+++ b/charts/cadence/templates/server-deployment.yaml
@@ -338,7 +338,11 @@ spec:
 
             # Wait for PostgreSQL to be ready
             echo "Waiting for PostgreSQL to be ready..."
-            until pg_isready -h $DB_HOST -p $DB_PORT -U $DB_USER; do
+            until pg_isready -d "host=$DB_HOST \
+              port=$DB_PORT \
+              dbname=$DB_NAME \
+              user=$DB_USER \
+              sslmode=${SSL_MODE:-disable}"; do
               echo 'PostgreSQL is not ready yet...'
               sleep 5
             done


### PR DESCRIPTION
#### Description of this PR
Add support for SSLMode on pg_isready check. Close #64 


#### Checklist

- [x] `Chart.yaml`: Chart `version` bumped
- [x] [DCO](https://github.com/cadence-workflow/cadence-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Test deployment locally