### PR TITLE
Add opensearch values

### DIFF
--- a/charts/cadence/Chart.lock
+++ b/charts/cadence/Chart.lock
@@ -11,8 +11,11 @@ dependencies:
 - name: elasticsearch
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 21.6.3
+- name: opensearch
+  repository: https://opensearch-project.github.io/helm-charts/
+  version: 2.36.0
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 30.1.8
-digest: sha256:794d39e9345acfb117730c963e7818fa388613b2cbb2becef8c3ce43d1e15206
-generated: "2025-11-03T14:00:44.205655-08:00"
+digest: sha256:087c1af31e91c47c94d3019711a90b274672fc562cf7d6d7fc650a322c5525a6
+generated: "2025-12-10T12:15:50.431821-08:00"

--- a/charts/cadence/Chart.yaml
+++ b/charts/cadence/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cadence
-version: 1.1.0
+version: 1.2.0
 appVersion: v1.3.6
 
 description: |

--- a/charts/cadence/Chart.yaml
+++ b/charts/cadence/Chart.yaml
@@ -44,6 +44,10 @@ dependencies:
     version: 21.6.x
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: elasticsearch.enabled
+  - name: opensearch
+    version: 2.x.x
+    repository: https://opensearch-project.github.io/helm-charts/
+    condition: opensearch.enabled
   - name: kafka
     version: 30.x.x
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/cadence/README.md
+++ b/charts/cadence/README.md
@@ -1,6 +1,6 @@
 # cadence
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.6](https://img.shields.io/badge/AppVersion-v1.3.6-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.6](https://img.shields.io/badge/AppVersion-v1.3.6-informational?style=flat-square)
 
 Cadence is a distributed, scalable, durable, and highly available orchestration engine
 to execute asynchronous long-running business logic in a scalable and resilient way.
@@ -23,6 +23,7 @@ This chart deploys Uber Cadence server components and web UI.
 
 | Repository | Name | Version |
 |------------|------|---------|
+| https://opensearch-project.github.io/helm-charts/ | opensearch | 2.x.x |
 | oci://registry-1.docker.io/bitnamicharts | cassandra | 11.x.x |
 | oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.6.x |
 | oci://registry-1.docker.io/bitnamicharts | kafka | 30.x.x |

--- a/charts/cadence/examples/values.postgres-os2.yaml
+++ b/charts/cadence/examples/values.postgres-os2.yaml
@@ -1,0 +1,208 @@
+# Namespace note: install into namespace: cadence-postgres-os2
+#
+# This example demonstrates Cadence deployment with:
+# - PostgreSQL for primary persistence
+# - OpenSearch v2 for advanced visibility
+# - Kafka for async visibility processing
+# - Security disabled for demo purposes (production should enable security)
+
+# Allow Bitnami charts to use legacy repository images
+global:
+  image:
+    tag: "v1.3.6"  # Default version 
+  security:
+    allowInsecureImages: true
+
+# Force Cadence to use PostgreSQL for main DB
+config:
+  persistence:
+    # Name of the default datastore (PostgreSQL)
+    defaultStore: "default"
+    # Disable basic SQL visibility (we're using OpenSearch-only via Kafka)
+    visibilityStore: ""
+    # Name of the advanced visibility datastore (OpenSearch)
+    # Note: This defines the datastore, but dynamic config controls how it's used
+    advancedVisibilityStore: "es-visibility"
+    database:
+      driver: "postgres"
+      sql:
+        hosts: "cadence-release-postgresql.cadence-postgres-os2.svc.cluster.local"
+        port: 5432
+        dbname: "cadence"
+        user: "cadence"
+        password: "changeme-strong"
+        tls:
+          enabled: false
+          sslMode: ""
+    elasticsearch:
+      enabled: true
+      version: "v7"
+      user: ""
+      password: ""
+      protocol: "http"
+      hosts: "opensearch-cluster-master.cadence-postgres-os2.svc.cluster.local"
+      port: 9200
+      visibilityIndex: "cadence-visibility-os2"
+      tls:
+        enabled: false
+  kafka: # needed by opensearch integration
+    enabled: true
+    brokers: "cadence-release-kafka.cadence-postgres-os2.svc.cluster.local"
+
+# Enable Cadence schema jobs
+schema:
+  serverJob:
+    enabled: true
+  elasticSearchJob:
+    enabled: true
+
+# Ensure Cadence uses OpenSearch for advanced visibility
+# Note: "es" is a special keyword for advanced visibility, not the datastore name
+dynamicConfig:
+  values:
+    system.writeVisibilityStoreName:
+      - value: "es"
+    system.readVisibilityStoreName:
+      - value: "es"
+
+### subcharts values which can be omited if user has their own deployment
+
+# Deploy Postgres within the same release (Bitnami subchart)
+postgresql:
+  enabled: true
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
+    tag: "16.4.0"
+    pullPolicy: IfNotPresent
+  auth:
+    username: cadence
+    password: "changeme-strong"
+    database: cadence
+  primary:
+    persistence:
+      enabled: true
+      size: 8Gi
+
+# Deploy OpenSearch with single node mode
+opensearch:
+  enabled: true
+  singleNode: true
+  replicas: 1
+  # Disable security for demo/test purposes (matches docker-compose setup)
+  config:
+    opensearch.yml: |
+      cluster.name: opensearch-cluster
+      network.host: 0.0.0.0
+      plugins.security.disabled: true
+  opensearchJavaOpts: "-Xms512m -Xmx512m"
+  resources:
+    requests:
+      cpu: 1
+      memory: 1Gi
+    limits:
+      cpu: 2
+      memory: 2Gi
+
+# Disable Elasticsearch subchart (we're using OpenSearch)
+elasticsearch:
+  enabled: false
+
+kafka:
+  enabled: true
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/kafka
+    tag: "3.8.0"
+    pullPolicy: IfNotPresent
+  # KRaft mode configuration (Kafka without ZooKeeper)
+  kraft:
+    enabled: true
+  # Disable ZooKeeper since we're using KRaft
+  zookeeper:
+    enabled: false
+  # Controller and broker configuration for KRaft
+  controller:
+    replicaCount: 1
+    persistence:
+      enabled: true
+      size: 8Gi
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: 1
+        memory: 2Gi
+    # GKE Autopilot compatibility
+    podSecurityContext:
+      fsGroup: 1001
+      runAsUser: 1001
+    containerSecurityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+  broker:
+    replicaCount: 1
+    persistence:
+      enabled: true
+      size: 8Gi
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: 1
+        memory: 2Gi
+    # GKE Autopilot compatibility
+    podSecurityContext:
+      fsGroup: 1001
+      runAsUser: 1001
+    containerSecurityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+  # GKE Autopilot compatibility: disable privileged init container
+  sysctlImage:
+    enabled: false
+  # Kafka topic configuration for Cadence visibility
+  autoCreateTopicsEnable: true
+  numPartitions: 4
+  defaultReplicationFactor: 1
+  # Configure replication factors for internal topics (demo/single-node setup)
+  offsetsTopicReplicationFactor: 1
+  transactionStateLogReplicationFactor: 1
+  transactionStateLogMinIsr: 1
+  # Provision topics at startup to avoid race conditions
+  provisioning:
+    enabled: true
+    topics:
+      - name: __consumer_offsets
+        partitions: 50
+        replicationFactor: 1
+        config:
+          cleanup.policy: compact
+          compression.type: producer
+      - name: cadence-visibility
+        partitions: 4
+        replicationFactor: 1
+      - name: cadence-visibility-dlq
+        partitions: 4
+        replicationFactor: 1
+  # Listener configuration
+  listeners:
+    client:
+      protocol: PLAINTEXT
+    controller:
+      protocol: PLAINTEXT
+    interbroker:
+      protocol: PLAINTEXT
+  # Service configuration
+  service:
+    type: ClusterIP
+    ports:
+      client: 9092
+
+# Do NOT deploy Cassandra or MySQL
+cassandra:
+  enabled: false
+mysql:
+  enabled: false


### PR DESCRIPTION
<!--
Thank you for contributing to cadence-workflow/cadence-charts.
Before you submit this pull request we'd like to make sure you are aware of our release process and best practices:

* https://github.com/cadence-workflow/cadence-charts/blob/main/CONTRIBUTING.md#release-process
* https://helm.sh/docs/chart_best_practices/
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### Description of this PR

This PR adds support for OpenSearch v2 as an advanced visibility backend for Cadence, providing an alternative to Elasticsearch.

**Changes:**

- Added OpenSearch Helm chart dependency to `Chart.yaml` (version 2.x.x from opensearch-project/helm-charts)
- Created new example values file: `charts/cadence/examples/values.postgres-os2.yaml`
  - Demonstrates PostgreSQL + OpenSearch v2 + Kafka deployment
  - Configures OpenSearch with security disabled for demo/development purposes
  - Uses v7 API compatibility (OpenSearch v2 is API-compatible with Elasticsearch v7)
  - Includes Kafka topic provisioning to avoid race conditions
  - Deploys to `cadence-postgres-os2` namespace
- Bumped chart version from 1.1.0 to 1.2.0 (minor version for new feature)
- Updated documentation via `helm-docs`

**Key Configuration Details:**

The example configures Cadence to use:
- PostgreSQL for primary persistence
- OpenSearch v2 for advanced visibility (using `version: "v7"` for API compatibility)
- Kafka for asynchronous visibility event processing
- Pre-provisioned Kafka topics (`__consumer_offsets`, `cadence-visibility`, `cadence-visibility-dlq`)
- OpenSearch service name: `opensearch-cluster-master` (from OpenSearch Helm chart)
- Visibility index: `cadence-visibility-os2`

**Testing:**

Deployed and tested in GKE Autopilot environment:
- All pods started successfully without errors
- Schema jobs completed (PostgreSQL and OpenSearch)
- Kafka topics provisioned correctly
- OpenSearch index created and verified healthy
- Workflow executions successfully indexed and searchable in Cadence Web UI

#### Checklist

- [x] `Chart.yaml`: Chart `version` bumped
- [x] `values.yaml`: `global.image.tag` (should match with `Chart.yaml` appVersion)
- [x] Dependencies in `Chart.yaml` (check for updates with `helm dependency update`, aim for latest major-1 stable)
- [x] [DCO](https://github.com/cadence-workflow/cadence-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Test deployment locally
- [x] Run `helm-docs` to update documentation