### PR TITLE
fix: Allow the helm chart to be deployed with any namespace and release name

### DIFF
--- a/charts/cadence/Chart.yaml
+++ b/charts/cadence/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cadence
-version: 1.2.1
+version: 1.3.0
 appVersion: v1.3.6
 
 description: |

--- a/charts/cadence/README.md
+++ b/charts/cadence/README.md
@@ -1,6 +1,6 @@
 # cadence
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.6](https://img.shields.io/badge/AppVersion-v1.3.6-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.6](https://img.shields.io/badge/AppVersion-v1.3.6-informational?style=flat-square)
 
 Cadence is a distributed, scalable, durable, and highly available orchestration engine
 to execute asynchronous long-running business logic in a scalable and resilient way.
@@ -116,7 +116,7 @@ This chart deploys Uber Cadence server components and web UI.
 | config.dynamicConfig.client | string | `"filebased"` | Dynamic config client type: noop, filebased, configstore |
 | config.dynamicConfig.filebased.filepath | string | `"/etc/cadence/config/dynamicconfig/config.yaml"` | Path to dynamic config file |
 | config.dynamicConfig.filebased.pollInterval | string | `"60s"` | Poll interval for config changes |
-| config.kafka.brokers | string | `"kafka-service.kafka-namespace.svc.cluster.local"` | Kafka broker service. Can reference Kubernetes services |
+| config.kafka.brokers | string | `""` | Kafka broker hostname. Auto-generated as {release-name}-kafka.{namespace}.svc.cluster.local when kafka.enabled=true. Set explicitly for external Kafka. |
 | config.kafka.enabled | bool | `false` | Enable Kafka for async workflows |
 | config.kafka.port | int | `9092` | Kafka port |
 | config.kafka.sasl.enabled | bool | `false` | Enable SASL authentication |
@@ -147,7 +147,7 @@ This chart deploys Uber Cadence server components and web UI.
 | config.persistence.database.cassandra.consistency | string | `"LOCAL_QUORUM"` | Default consistency level |
 | config.persistence.database.cassandra.datacenter | string | `""` | Datacenter filter for Cassandra (Used for schema setup too) |
 | config.persistence.database.cassandra.hostSelectionPolicy | string | `"tokenaware,roundrobin"` | Host selection policy |
-| config.persistence.database.cassandra.hosts | string | `"cadence-release-cassandra.cadencetest.svc.cluster.local"` | Cassandra hosts. Can reference Kubernetes services |
+| config.persistence.database.cassandra.hosts | string | `""` | Cassandra hosts. Auto-generated as {release-name}-cassandra.{namespace}.svc.cluster.local when cassandra.enabled=true. Set this for external Cassandra. |
 | config.persistence.database.cassandra.keyspace | string | `"cadence"` | Cassandra keyspace for main data |
 | config.persistence.database.cassandra.maxConns | int | `10` | Maximum number of connections |
 | config.persistence.database.cassandra.password | string | `"cassandra"` | Cassandra password |
@@ -175,7 +175,7 @@ This chart deploys Uber Cadence server components and web UI.
 | config.persistence.database.sql.dbname | string | `"cadence"` | Database name for main data |
 | config.persistence.database.sql.decodingTypes | list | `["thriftrw"]` | Decoding types for SQL blobs |
 | config.persistence.database.sql.encodingType | string | `"thriftrw"` | Encoding type for SQL blobs |
-| config.persistence.database.sql.hosts | string | `"mysql-service.mysql-namespace.svc.cluster.local"` | Database host. Can reference Kubernetes services |
+| config.persistence.database.sql.hosts | string | `""` | Database host. Auto-generated as {release-name}-{db}.{namespace}.svc.cluster.local when postgresql/mysql.enabled=true |
 | config.persistence.database.sql.maxConnLifetime | string | `"1h"` | Maximum connection lifetime |
 | config.persistence.database.sql.maxConns | int | `20` | Maximum number of connections |
 | config.persistence.database.sql.maxIdleConns | int | `20` | Maximum number of idle connections |
@@ -198,7 +198,7 @@ This chart deploys Uber Cadence server components and web UI.
 | config.persistence.defaultStore | string | `"default"` | Name of the default datastore |
 | config.persistence.elasticsearch.awsSigning | object | `{"enabled":false,"region":"","service":"es"}` | Enable AWS signing (for AWS Elasticsearch) |
 | config.persistence.elasticsearch.enabled | bool | `false` | Enable Elasticsearch for advanced visibility |
-| config.persistence.elasticsearch.hosts | string | `"elasticsearch-service.elastic-namespace.svc.cluster.local"` | Elasticsearch host. |
+| config.persistence.elasticsearch.hosts | string | `""` | Elasticsearch host. Auto-generated as {release-name}-elasticsearch.{namespace}.svc.cluster.local when elasticsearch.enabled=true |
 | config.persistence.elasticsearch.password | string | `""` | Elasticsearch password |
 | config.persistence.elasticsearch.port | int | `9200` | Elasticsearch port |
 | config.persistence.elasticsearch.protocol | string | `""` | Protocol to use (http/https). If not specified, auto-detected based on TLS settings |

--- a/charts/cadence/examples/values.postgres-es7.yaml
+++ b/charts/cadence/examples/values.postgres-es7.yaml
@@ -2,8 +2,6 @@
 
 # Allow Bitnami charts to use legacy repository images
 global:
-  image:
-    tag: "v1.3.6"  # Default version 
   security:
     allowInsecureImages: true
 
@@ -20,7 +18,9 @@ config:
     database:
       driver: "postgres"
       sql:
-        hosts: "cadence-release-postgresql.cadence-postgres-es7.svc.cluster.local"
+        # Hostname auto-generated as {release-name}-postgresql.{namespace}.svc.cluster.local
+        # when postgresql.enabled=true. Set explicitly for external PostgreSQL.
+        hosts: ""
         port: 5432
         dbname: "cadence"
         user: "cadence"
@@ -34,14 +34,18 @@ config:
       user: ""
       password: ""
       protocol: "http"
-      hosts: "cadence-release-elasticsearch.cadence-postgres-es7.svc.cluster.local"
+      # Hostname auto-generated as {release-name}-elasticsearch.{namespace}.svc.cluster.local
+      # when elasticsearch.enabled=true. Set explicitly for external Elasticsearch.
+      hosts: ""
       port: 9200
       visibilityIndex: "cadence-visibility-es7"
       tls:
         enabled: false
   kafka: # needed by elasticsearch integration
     enabled: true
-    brokers: "cadence-release-kafka.cadence-postgres-es7.svc.cluster.local"
+    # Hostname auto-generated as {release-name}-kafka.{namespace}.svc.cluster.local
+    # when kafka.enabled=true. Set explicitly for external Kafka.
+    brokers: ""
 
 # Enable Cadence schema jobs
 schema:

--- a/charts/cadence/examples/values.postgres-os2.yaml
+++ b/charts/cadence/examples/values.postgres-os2.yaml
@@ -26,7 +26,9 @@ config:
     database:
       driver: "postgres"
       sql:
-        hosts: "cadence-release-postgresql.cadence-postgres-os2.svc.cluster.local"
+        # Hostname auto-generated as {release-name}-postgresql.{namespace}.svc.cluster.local
+        # when postgresql.enabled=true. Set explicitly for external PostgreSQL.
+        hosts: ""
         port: 5432
         dbname: "cadence"
         user: "cadence"
@@ -36,18 +38,22 @@ config:
           sslMode: ""
     elasticsearch:
       enabled: true
-      version: "v7"
+      version: "os2"
       user: ""
       password: ""
       protocol: "http"
-      hosts: "opensearch-cluster-master.cadence-postgres-os2.svc.cluster.local"
+      # Hostname auto-generated as opensearch-cluster-master.{namespace}.svc.cluster.local
+      # when opensearch.enabled=true (based on opensearch.clusterName). Set explicitly for external OpenSearch.
+      hosts: ""
       port: 9200
       visibilityIndex: "cadence-visibility-os2"
       tls:
         enabled: false
   kafka: # needed by opensearch integration
     enabled: true
-    brokers: "cadence-release-kafka.cadence-postgres-os2.svc.cluster.local"
+    # Hostname auto-generated as {release-name}-kafka.{namespace}.svc.cluster.local
+    # when kafka.enabled=true. Set explicitly for external Kafka.
+    brokers: ""
 
 # Enable Cadence schema jobs
 schema:

--- a/charts/cadence/examples/values.postgres.yaml
+++ b/charts/cadence/examples/values.postgres.yaml
@@ -9,7 +9,9 @@ config:
     database:
       driver: "postgres"
       sql:
-        hosts: "cadence-release-postgresql.cadence-postgres.svc.cluster.local"
+        # Hostname auto-generated as {release-name}-postgresql.{namespace}.svc.cluster.local
+        # when postgresql.enabled=true. Set explicitly for external PostgreSQL.
+        hosts: ""
         port: 5432
         dbname: "cadence"
         visibilityDbname: "cadence_visibility"

--- a/charts/cadence/templates/_helpers.tpl
+++ b/charts/cadence/templates/_helpers.tpl
@@ -93,6 +93,200 @@ Check if HPA is enabled for a specific service
 {{- end }}
 
 {{/*
+Generate Cassandra hostname dynamically
+Replicates Bitnami's service naming logic:
+- If cassandra.fullnameOverride is set, use it
+- Else if cassandra.nameOverride is set, use {release-name}-{nameOverride}
+- Else use {release-name}-cassandra
+NOTE: If you modify the chart dependency name in Chart.yaml, set config.persistence.database.cassandra.hosts manually
+*/}}
+{{- define "cadence.cassandraHost" -}}
+  {{- if .Values.cassandra.enabled -}}
+    {{- $serviceName := "" -}}
+    {{- if .Values.cassandra.fullnameOverride -}}
+      {{- $serviceName = .Values.cassandra.fullnameOverride -}}
+    {{- else if .Values.cassandra.nameOverride -}}
+      {{- $serviceName = printf "%s-%s" .Release.Name .Values.cassandra.nameOverride -}}
+    {{- else -}}
+      {{- $serviceName = printf "%s-cassandra" .Release.Name -}}
+    {{- end -}}
+    {{- printf "%s.%s.svc.cluster.local" $serviceName .Release.Namespace -}}
+  {{- else if .Values.config.persistence.database.cassandra.hosts -}}
+    {{- .Values.config.persistence.database.cassandra.hosts -}}
+  {{- else -}}
+    {{- fail "config.persistence.database.cassandra.hosts must be set when cassandra.enabled is false" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Generate PostgreSQL hostname dynamically
+Replicates Bitnami's service naming logic:
+- If postgresql.fullnameOverride is set, use it
+- Else if postgresql.nameOverride is set, use {release-name}-{nameOverride}
+- Else use {release-name}-postgresql
+*/}}
+{{- define "cadence.postgresqlHost" -}}
+  {{- if .Values.postgresql.enabled -}}
+    {{- $serviceName := "" -}}
+    {{- if .Values.postgresql.fullnameOverride -}}
+      {{- $serviceName = .Values.postgresql.fullnameOverride -}}
+    {{- else if .Values.postgresql.nameOverride -}}
+      {{- $serviceName = printf "%s-%s" .Release.Name .Values.postgresql.nameOverride -}}
+    {{- else -}}
+      {{- $serviceName = printf "%s-postgresql" .Release.Name -}}
+    {{- end -}}
+    {{- printf "%s.%s.svc.cluster.local" $serviceName .Release.Namespace -}}
+  {{- else if .Values.config.persistence.database.sql.hosts -}}
+    {{- .Values.config.persistence.database.sql.hosts -}}
+  {{- else -}}
+    {{- fail "config.persistence.database.sql.hosts must be set when postgresql.enabled is false" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Generate MySQL hostname dynamically
+Replicates Bitnami's service naming logic:
+- If mysql.fullnameOverride is set, use it
+- Else if mysql.nameOverride is set, use {release-name}-{nameOverride}
+- Else use {release-name}-mysql
+*/}}
+{{- define "cadence.mysqlHost" -}}
+  {{- if .Values.mysql.enabled -}}
+    {{- $serviceName := "" -}}
+    {{- if .Values.mysql.fullnameOverride -}}
+      {{- $serviceName = .Values.mysql.fullnameOverride -}}
+    {{- else if .Values.mysql.nameOverride -}}
+      {{- $serviceName = printf "%s-%s" .Release.Name .Values.mysql.nameOverride -}}
+    {{- else -}}
+      {{- $serviceName = printf "%s-mysql" .Release.Name -}}
+    {{- end -}}
+    {{- printf "%s.%s.svc.cluster.local" $serviceName .Release.Namespace -}}
+  {{- else if .Values.config.persistence.database.sql.hosts -}}
+    {{- .Values.config.persistence.database.sql.hosts -}}
+  {{- else -}}
+    {{- fail "config.persistence.database.sql.hosts must be set when mysql.enabled is false" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Generate SQL database hostname dynamically (PostgreSQL or MySQL based on driver)
+*/}}
+{{- define "cadence.sqlHost" -}}
+  {{- if eq .Values.config.persistence.database.driver "postgres" -}}
+  {{- include "cadence.postgresqlHost" . -}}
+  {{- else if eq .Values.config.persistence.database.driver "mysql" -}}
+  {{- include "cadence.mysqlHost" . -}}
+  {{- else -}}
+  {{- .Values.config.persistence.database.sql.hosts | default "" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Generate Elasticsearch hostname dynamically
+Replicates Bitnami's service naming logic:
+- If elasticsearch.fullnameOverride is set, use it
+- Else if elasticsearch.nameOverride is set, use {release-name}-{nameOverride}
+- Else use {release-name}-elasticsearch
+NOTE: If you modify the chart dependency name in Chart.yaml, set config.persistence.elasticsearch.hosts manually
+*/}}
+{{- define "cadence.elasticsearchHost" -}}
+  {{- if .Values.elasticsearch.enabled -}}
+    {{- $serviceName := "" -}}
+    {{- if .Values.elasticsearch.fullnameOverride -}}
+      {{- $serviceName = .Values.elasticsearch.fullnameOverride -}}
+    {{- else if .Values.elasticsearch.nameOverride -}}
+      {{- $serviceName = printf "%s-%s" .Release.Name .Values.elasticsearch.nameOverride -}}
+    {{- else -}}
+      {{- $serviceName = printf "%s-elasticsearch" .Release.Name -}}
+    {{- end -}}
+    {{- printf "%s.%s.svc.cluster.local" $serviceName .Release.Namespace -}}
+  {{- else if .Values.config.persistence.elasticsearch.hosts -}}
+    {{- .Values.config.persistence.elasticsearch.hosts -}}
+  {{- else -}}
+    {{- fail "config.persistence.elasticsearch.hosts must be set when elasticsearch.enabled is false" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Generate OpenSearch hostname dynamically
+Replicates OpenSearch chart's opensearch.masterService logic:
+- If masterService is set, use it
+- Else if fullnameOverride is set, use it (no -master suffix)
+- Else if nameOverride is set, use {nameOverride}-master
+- Else use {clusterName}-master (defaults to opensearch-cluster-master)
+NOTE: If you modify the chart dependency name in Chart.yaml, set config.persistence.elasticsearch.hosts manually
+*/}}
+{{- define "cadence.opensearchHost" -}}
+  {{- if .Values.opensearch.enabled -}}
+    {{- $serviceName := "" -}}
+    {{- if .Values.opensearch.masterService -}}
+      {{- $serviceName = .Values.opensearch.masterService -}}
+    {{- else if .Values.opensearch.fullnameOverride -}}
+      {{- $serviceName = .Values.opensearch.fullnameOverride -}}
+    {{- else if .Values.opensearch.nameOverride -}}
+      {{- $serviceName = printf "%s-master" .Values.opensearch.nameOverride -}}
+    {{- else -}}
+      {{- $clusterName := .Values.opensearch.clusterName | default "opensearch-cluster" -}}
+      {{- $serviceName = printf "%s-master" $clusterName -}}
+    {{- end -}}
+    {{- printf "%s.%s.svc.cluster.local" $serviceName .Release.Namespace -}}
+  {{- else if .Values.config.persistence.elasticsearch.hosts -}}
+    {{- .Values.config.persistence.elasticsearch.hosts -}}
+  {{- else -}}
+    {{- fail "config.persistence.elasticsearch.hosts must be set when opensearch.enabled is false" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Generate search engine hostname (Elasticsearch or OpenSearch)
+Automatically detects which is enabled
+Fails if both are enabled simultaneously
+If both are disabled but search is needed, requires manual hosts configuration
+*/}}
+{{- define "cadence.searchHost" -}}
+  {{- if and .Values.elasticsearch.enabled .Values.opensearch.enabled -}}
+    {{- fail "Cannot enable both elasticsearch.enabled and opensearch.enabled. Choose one." -}}
+  {{- else if .Values.elasticsearch.enabled -}}
+  {{- include "cadence.elasticsearchHost" . -}}
+  {{- else if .Values.opensearch.enabled -}}
+  {{- include "cadence.opensearchHost" . -}}
+  {{- else -}}
+    {{- if .Values.config.persistence.elasticsearch.enabled -}}
+      {{- if not .Values.config.persistence.elasticsearch.hosts -}}
+        {{- fail "config.persistence.elasticsearch.hosts must be set when both elasticsearch.enabled and opensearch.enabled are false but search is enabled" -}}
+      {{- end -}}
+    {{- end -}}
+    {{- .Values.config.persistence.elasticsearch.hosts | default "" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Generate Kafka broker hostname dynamically
+Replicates Bitnami's service naming logic:
+- If kafka.fullnameOverride is set, use it
+- Else if kafka.nameOverride is set, use {release-name}-{nameOverride}
+- Else use {release-name}-kafka
+NOTE: If you modify the chart dependency name in Chart.yaml, set config.kafka.brokers manually
+*/}}
+{{- define "cadence.kafkaBroker" -}}
+  {{- if .Values.kafka.enabled -}}
+    {{- $serviceName := "" -}}
+    {{- if .Values.kafka.fullnameOverride -}}
+      {{- $serviceName = .Values.kafka.fullnameOverride -}}
+    {{- else if .Values.kafka.nameOverride -}}
+      {{- $serviceName = printf "%s-%s" .Release.Name .Values.kafka.nameOverride -}}
+    {{- else -}}
+      {{- $serviceName = printf "%s-kafka" .Release.Name -}}
+    {{- end -}}
+    {{- printf "%s.%s.svc.cluster.local" $serviceName .Release.Namespace -}}
+  {{- else if .Values.config.kafka.brokers -}}
+    {{- .Values.config.kafka.brokers -}}
+  {{- else -}}
+    {{- fail "config.kafka.brokers must be set when kafka.enabled is false" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Helper to generate database and service secrets based on configuration
 Receives context as parameter
 */}}

--- a/charts/cadence/templates/schema-elasticsearch-job.yaml
+++ b/charts/cadence/templates/schema-elasticsearch-job.yaml
@@ -128,7 +128,7 @@ spec:
         env:
         # Basic Elasticsearch connection parameters
         - name: ES_HOST
-          value: {{ $.Values.config.persistence.elasticsearch.hosts | quote }}
+          value: {{ include "cadence.searchHost" $ | quote }}
         - name: ES_PORT
           value: {{ $.Values.config.persistence.elasticsearch.port | default 9200 | quote }}
         - name: ES_PROTOCOL
@@ -396,7 +396,7 @@ spec:
         env:
         # Basic Elasticsearch connection parameters
         - name: ES_HOST
-          value: {{ $.Values.config.persistence.elasticsearch.hosts | quote }}
+          value: {{ include "cadence.searchHost" $ | quote }}
         - name: ES_PORT
           value: {{ $.Values.config.persistence.elasticsearch.port | default 9200 | quote }}
         - name: ES_PROTOCOL

--- a/charts/cadence/templates/schema-server-job.yaml
+++ b/charts/cadence/templates/schema-server-job.yaml
@@ -148,7 +148,7 @@ spec:
           value: {{ $.Values.config.persistence.elasticsearch.enabled | quote }}
         # Basic connection parameters
         - name: DB_HOST
-          value: {{ $.Values.config.persistence.database.cassandra.hosts | quote }}
+          value: {{ include "cadence.cassandraHost" $ | quote }}
         - name: DB_PORT
           value: {{ $.Values.config.persistence.database.cassandra.port | quote }}
         - name: DB_NAME
@@ -237,7 +237,7 @@ spec:
           value: {{ $.Values.config.persistence.elasticsearch.enabled | quote }}
         # Basic connection parameters
         - name: DB_HOST
-          value: {{ $.Values.config.persistence.database.sql.hosts | quote }}
+          value: {{ include "cadence.sqlHost" $ | quote }}
         - name: DB_PORT
           value: {{ $.Values.config.persistence.database.postgres.port | default $.Values.config.persistence.database.sql.port | default 5432 | quote }}
         - name: DB_NAME
@@ -342,7 +342,7 @@ spec:
           value: {{ $.Values.config.persistence.elasticsearch.enabled | quote }}
         # Basic connection parameters
         - name: DB_HOST
-          value: {{ $.Values.config.persistence.database.sql.hosts | quote }}
+          value: {{ include "cadence.sqlHost" $ | quote }}
         - name: DB_PORT
           value: {{ $.Values.config.persistence.database.mysql.port | default $.Values.config.persistence.database.sql.port | default 3306 | quote }}
         - name: DB_NAME
@@ -487,7 +487,7 @@ spec:
           value: {{ .Values.config.persistence.elasticsearch.enabled | quote }}
         # Cassandra specific environment variables
         - name: DB_HOST
-          value: {{ .Values.config.persistence.database.cassandra.hosts | quote }}
+          value: {{ include "cadence.cassandraHost" $ | quote }}
         - name: DB_NAME
           value: {{ .Values.config.persistence.database.cassandra.keyspace | quote }}
         - name: PROTOCOL_VERSION
@@ -605,7 +605,7 @@ spec:
           value: {{ .Values.config.persistence.elasticsearch.enabled | quote }}
         # PostgreSQL specific environment variables
         - name: DB_HOST
-          value: {{ .Values.config.persistence.database.sql.hosts | quote }}
+          value: {{ include "cadence.sqlHost" . | quote }}
         - name: DB_PORT
           value: {{ .Values.config.persistence.database.postgres.port | default .Values.config.persistence.database.sql.port | default 5432 | quote }}
         - name: DB_NAME
@@ -710,7 +710,7 @@ spec:
           value: {{ .Values.config.persistence.elasticsearch.enabled | quote }}
         # MySQL specific environment variables
         - name: DB_HOST
-          value: {{ .Values.config.persistence.database.sql.hosts | quote }}
+          value: {{ include "cadence.sqlHost" . | quote }}
         - name: DB_PORT
           value: {{ .Values.config.persistence.database.mysql.port | default .Values.config.persistence.database.sql.port | default 3306 | quote }}
         - name: DB_NAME

--- a/charts/cadence/templates/server-configmap.yaml
+++ b/charts/cadence/templates/server-configmap.yaml
@@ -57,7 +57,7 @@ data:
           {{- if eq .Values.config.persistence.database.driver "cassandra" }}
           nosql:
             pluginName: "cassandra"
-            hosts: {{ .Values.config.persistence.database.cassandra.hosts | quote }}
+            hosts: {{ include "cadence.cassandraHost" . | quote }}
             {{- $port := .Values.config.persistence.database.cassandra.port | default 9042 | int }}
             {{- if ne $port 9042 }}
             port: {{ $port }}
@@ -138,11 +138,11 @@ data:
             {{- if eq .Values.config.persistence.database.driver "mysql" }}
             pluginName: "mysql"
             {{- $port := .Values.config.persistence.database.mysql.port | default .Values.config.persistence.database.sql.port | default 3306 }}
-            connectAddr: "{{ .Values.config.persistence.database.sql.hosts }}:{{ $port }}"
+            connectAddr: "{{ include "cadence.sqlHost" . }}:{{ $port }}"
             {{- else if eq .Values.config.persistence.database.driver "postgres" }}
             pluginName: "postgres"
             {{- $port := .Values.config.persistence.database.postgres.port | default .Values.config.persistence.database.sql.port | default 5432 }}
-            connectAddr: "{{ .Values.config.persistence.database.sql.hosts }}:{{ $port }}"
+            connectAddr: "{{ include "cadence.sqlHost" . }}:{{ $port }}"
             {{- end }}
             connectProtocol: "tcp"
             databaseName: {{ .Values.config.persistence.database.sql.dbname | default "cadence" | quote }}
@@ -226,7 +226,7 @@ data:
           {{- if eq .Values.config.persistence.database.driver "cassandra" }}
           nosql:
             pluginName: "cassandra"
-            hosts: {{ .Values.config.persistence.database.cassandra.hosts | quote }}
+            hosts: {{ include "cadence.cassandraHost" . | quote }}
             {{- $port := .Values.config.persistence.database.cassandra.port | default 9042 | int }}
             {{- if ne $port 9042 }}
             port: {{ $port }}
@@ -307,11 +307,11 @@ data:
             {{- if eq .Values.config.persistence.database.driver "mysql" }}
             pluginName: "mysql"
             {{- $port := .Values.config.persistence.database.mysql.port | default .Values.config.persistence.database.sql.port | default 3306 }}
-            connectAddr: "{{ .Values.config.persistence.database.sql.hosts }}:{{ $port }}"
+            connectAddr: "{{ include "cadence.sqlHost" . }}:{{ $port }}"
             {{- else if eq .Values.config.persistence.database.driver "postgres" }}
             pluginName: "postgres"
             {{- $port := .Values.config.persistence.database.postgres.port | default .Values.config.persistence.database.sql.port | default 5432 }}
-            connectAddr: "{{ .Values.config.persistence.database.sql.hosts }}:{{ $port }}"
+            connectAddr: "{{ include "cadence.sqlHost" . }}:{{ $port }}"
             {{- end }}
             connectProtocol: "tcp"
             databaseName: {{ .Values.config.persistence.database.sql.visibilityDbname | default "cadence_visibility" | quote }}
@@ -406,7 +406,7 @@ data:
               {{- else }}
               scheme: "http"
               {{- end }}
-              host: {{ .Values.config.persistence.elasticsearch.hosts }}:{{ .Values.config.persistence.elasticsearch.port | default 9200 }}
+              host: {{ include "cadence.searchHost" . }}:{{ .Values.config.persistence.elasticsearch.port | default 9200 }}
             indices:
               visibility: {{ .Values.config.persistence.elasticsearch.visibilityIndex | default "cadence-visibility" | quote }}
             {{- if .Values.config.persistence.elasticsearch.user }}
@@ -620,7 +620,7 @@ data:
       clusters:
         default:
           brokers:
-            - {{ .Values.config.kafka.brokers }}:{{ .Values.config.kafka.port | default 9092 }}
+            - {{ include "cadence.kafkaBroker" . }}:{{ .Values.config.kafka.port | default 9092 }}
       topics:
         {{ .Values.config.kafka.visibilityTopic | default "cadence-visibility" }}:
           cluster: default

--- a/charts/cadence/templates/server-deployment.yaml
+++ b/charts/cadence/templates/server-deployment.yaml
@@ -247,7 +247,7 @@ spec:
           value: {{ $.Values.config.persistence.elasticsearch.enabled | quote }}
         # Basic connection parameters
         - name: DB_HOST
-          value: {{ $.Values.config.persistence.database.cassandra.hosts | quote }}
+          value: {{ include "cadence.cassandraHost" $ | quote }}
         - name: DB_PORT
           value: {{ $.Values.config.persistence.database.cassandra.port | quote }}
         - name: DB_NAME
@@ -371,7 +371,7 @@ spec:
           value: {{ $.Values.config.persistence.elasticsearch.enabled | quote }}
         # Basic connection parameters
         - name: DB_HOST
-          value: {{ $.Values.config.persistence.database.sql.hosts | quote }}
+          value: {{ include "cadence.sqlHost" $ | quote }}
         - name: DB_PORT
           value: {{ $.Values.config.persistence.database.postgres.port | default $.Values.config.persistence.database.sql.port | default 5432 | quote }}
         - name: DB_NAME
@@ -509,7 +509,7 @@ spec:
           value: {{ $.Values.config.persistence.elasticsearch.enabled | quote }}
         # Basic connection parameters
         - name: DB_HOST
-          value: {{ $.Values.config.persistence.database.sql.hosts | quote }}
+          value: {{ include "cadence.sqlHost" $ | quote }}
         - name: DB_PORT
           value: {{ $.Values.config.persistence.database.mysql.port | default $.Values.config.persistence.database.sql.port | default 3306 | quote }}
         - name: DB_NAME
@@ -734,7 +734,7 @@ spec:
         env:
         # Basic Elasticsearch connection parameters
         - name: ES_HOST
-          value: {{ $.Values.config.persistence.elasticsearch.hosts | quote }}
+          value: {{ include "cadence.searchHost" $ | quote }}
         - name: ES_PORT
           value: {{ $.Values.config.persistence.elasticsearch.port | default 9200 | quote }}
         - name: ES_PROTOCOL

--- a/charts/cadence/values.yaml
+++ b/charts/cadence/values.yaml
@@ -716,8 +716,8 @@ config:
 
       # Common SQL configuration (applies to both MySQL and PostgreSQL)
       sql:
-        # -- Database host. Can reference Kubernetes services
-        hosts: "mysql-service.mysql-namespace.svc.cluster.local"
+        # -- Database host. Auto-generated as {release-name}-{db}.{namespace}.svc.cluster.local when postgresql/mysql.enabled=true
+        hosts: ""
         # -- Database port (will use driver default if not specified)
         port: null
         # -- Database name for main data
@@ -782,8 +782,8 @@ config:
 
       # Cassandra configuration
       cassandra:
-        # -- Cassandra hosts. Can reference Kubernetes services
-        hosts: "cadence-release-cassandra.cadencetest.svc.cluster.local"
+        # -- Cassandra hosts. Auto-generated as {release-name}-cassandra.{namespace}.svc.cluster.local when cassandra.enabled=true. Set this for external Cassandra.
+        hosts: ""
         # -- Cassandra port
         port: 9042
         # -- Cassandra keyspace for main data
@@ -849,8 +849,8 @@ config:
       password: ""
       # -- Protocol to use (http/https). If not specified, auto-detected based on TLS settings
       protocol: ""
-      # -- Elasticsearch host.
-      hosts: "elasticsearch-service.elastic-namespace.svc.cluster.local"
+      # -- Elasticsearch host. Auto-generated as {release-name}-elasticsearch.{namespace}.svc.cluster.local when elasticsearch.enabled=true
+      hosts: ""
       # -- Elasticsearch port
       port: 9200
       # -- Elasticsearch visibility index name
@@ -950,8 +950,9 @@ config:
   kafka:
     # -- Enable Kafka for async workflows
     enabled: false
-    # -- Kafka broker service. Can reference Kubernetes services
-    brokers: "kafka-service.kafka-namespace.svc.cluster.local"
+    # -- Kafka broker hostname. Auto-generated as {release-name}-kafka.{namespace}.svc.cluster.local
+    # when kafka.enabled=true. Set explicitly for external Kafka.
+    brokers: ""
     # -- Kafka port
     port: 9092
     # -- Kafka visibility topic name


### PR DESCRIPTION

<!--
Thank you for contributing to cadence-workflow/cadence-charts.
Before you submit this pull request we'd like to make sure you are aware of our release process and best practices:

* https://github.com/cadence-workflow/cadence-charts/blob/main/CONTRIBUTING.md#release-process
* https://helm.sh/docs/chart_best_practices/
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### Description of this PR
Allow the helm chart to be deployed with any namespace and release name

Previously, the helm chart must be deployed with certain release name and in certain namespace. 
After this change, it removes the restriction.


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] `Chart.yaml`: Chart `version` bumped
- [x] `values.yaml`: `global.image.tag` (should match with `Chart.yaml` appVersion)
- [x] Dependencies in `Chart.yaml` (check for updates with `helm dependency update`, aim for latest major-1 stable)
- [x] [DCO](https://github.com/cadence-workflow/cadence-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Test deployment locally
- [x] Run `helm-docs` to update documentation