### PR TITLE
Update helm chart to support cloud SQL deployment

### DIFF
--- a/charts/cadence/Chart.yaml
+++ b/charts/cadence/Chart.yaml
@@ -2,6 +2,8 @@ apiVersion: v2
 name: cadence
 version: 1.3.2
 appVersion: v1.3.6
+# Requires Kubernetes 1.29+ for native sidecar init containers (Cloud SQL Proxy)
+kubeVersion: ">=1.29.0-0"
 
 description: |
   Cadence is a distributed, scalable, durable, and highly available orchestration engine

--- a/charts/cadence/Chart.yaml
+++ b/charts/cadence/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cadence
-version: 1.3.1
+version: 1.3.2
 appVersion: v1.3.6
 
 description: |

--- a/charts/cadence/Chart.yaml
+++ b/charts/cadence/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cadence
-version: 1.3.2
+version: 1.4.0
 appVersion: v1.3.6
 # Requires Kubernetes 1.29+ for native sidecar init containers (Cloud SQL Proxy)
 kubeVersion: ">=1.29.0-0"

--- a/charts/cadence/README.md
+++ b/charts/cadence/README.md
@@ -1,6 +1,6 @@
 # cadence
 
-![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.6](https://img.shields.io/badge/AppVersion-v1.3.6-informational?style=flat-square)
+![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.6](https://img.shields.io/badge/AppVersion-v1.3.6-informational?style=flat-square)
 
 Cadence is a distributed, scalable, durable, and highly available orchestration engine
 to execute asynchronous long-running business logic in a scalable and resilient way.
@@ -72,6 +72,14 @@ This chart deploys Uber Cadence server components and web UI.
 | cassandra.tls.resourcesPreset | string | `"nano"` | Resource preset for TLS containers |
 | cassandra.tls.tlsEncryptionSecretName | string | `""` | TLS encryption secret name |
 | cassandra.tls.truststorePassword | string | `""` | Truststore password |
+| cloudSqlProxy.autoIamAuthn | bool | `false` | Enable automatic IAM authentication (requires proper IAM permissions, no database password needed) |
+| cloudSqlProxy.enabled | bool | `false` | Enable Cloud SQL Proxy sidecar container |
+| cloudSqlProxy.extraArgs | list | `[]` | Additional command-line arguments for cloud-sql-proxy Example: ["--max-connections=100", "--max-sigterm-delay=30s"] |
+| cloudSqlProxy.image | object | `{"pullPolicy":"IfNotPresent","repository":"gcr.io/cloud-sql-connectors/cloud-sql-proxy","tag":"2.14.1"}` | Cloud SQL Proxy image |
+| cloudSqlProxy.instanceConnectionName | string | `""` | Cloud SQL instance connection name (format: project:region:instance) |
+| cloudSqlProxy.port | int | `5432` | Port for Cloud SQL Proxy to listen on |
+| cloudSqlProxy.privateIp | bool | `false` | Use private IP for Cloud SQL instance connection (requires VPC peering) |
+| cloudSqlProxy.resources | object | `{"limits":{"cpu":"200m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Resource limits and requests for the proxy sidecar |
 | config.archival.history.enableRead | bool | `false` | Enable reading from archives |
 | config.archival.history.provider | object | `{"filestore":{"dirMode":"0755","fileMode":"0644"},"gstorage":{"credentialsPath":""},"s3store":{"endpoint":"","region":"","s3ForcePathStyle":false},"type":"filestore"}` | Archive providers configuration |
 | config.archival.history.provider.filestore.dirMode | string | `"0755"` | Directory mode for archive directories |

--- a/charts/cadence/README.md
+++ b/charts/cadence/README.md
@@ -1,6 +1,6 @@
 # cadence
 
-![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.6](https://img.shields.io/badge/AppVersion-v1.3.6-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.6](https://img.shields.io/badge/AppVersion-v1.3.6-informational?style=flat-square)
 
 Cadence is a distributed, scalable, durable, and highly available orchestration engine
 to execute asynchronous long-running business logic in a scalable and resilient way.
@@ -20,6 +20,8 @@ This chart deploys Uber Cadence server components and web UI.
 * <https://github.com/cadence-workflow/cadence-web>
 
 ## Requirements
+
+Kubernetes: `>=1.29.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
@@ -72,14 +74,9 @@ This chart deploys Uber Cadence server components and web UI.
 | cassandra.tls.resourcesPreset | string | `"nano"` | Resource preset for TLS containers |
 | cassandra.tls.tlsEncryptionSecretName | string | `""` | TLS encryption secret name |
 | cassandra.tls.truststorePassword | string | `""` | Truststore password |
-| cloudSqlProxy.autoIamAuthn | bool | `false` | Enable automatic IAM authentication (requires proper IAM permissions, no database password needed) |
-| cloudSqlProxy.enabled | bool | `false` | Enable Cloud SQL Proxy sidecar container |
-| cloudSqlProxy.extraArgs | list | `[]` | Additional command-line arguments for cloud-sql-proxy Example: ["--max-connections=100", "--max-sigterm-delay=30s"] |
-| cloudSqlProxy.image | object | `{"pullPolicy":"IfNotPresent","repository":"gcr.io/cloud-sql-connectors/cloud-sql-proxy","tag":"2.14.1"}` | Cloud SQL Proxy image |
-| cloudSqlProxy.instanceConnectionName | string | `""` | Cloud SQL instance connection name (format: project:region:instance) |
-| cloudSqlProxy.port | int | `5432` | Port for Cloud SQL Proxy to listen on |
-| cloudSqlProxy.privateIp | bool | `false` | Use private IP for Cloud SQL instance connection (requires VPC peering) |
-| cloudSqlProxy.resources | object | `{"limits":{"cpu":"200m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Resource limits and requests for the proxy sidecar |
+| cloudSqlProxy.container | object | `{}` | Regular sidecar container specification Uncomment and configure to add a database proxy as a regular container |
+| cloudSqlProxy.enabled | bool | `false` | Enable database proxy containers |
+| cloudSqlProxy.initContainer | object | `{}` | Init container specification (runs as native sidecar with restartPolicy: Always) Uncomment and configure to add a database proxy init container |
 | config.archival.history.enableRead | bool | `false` | Enable reading from archives |
 | config.archival.history.provider | object | `{"filestore":{"dirMode":"0755","fileMode":"0644"},"gstorage":{"credentialsPath":""},"s3store":{"endpoint":"","region":"","s3ForcePathStyle":false},"type":"filestore"}` | Archive providers configuration |
 | config.archival.history.provider.filestore.dirMode | string | `"0755"` | Directory mode for archive directories |

--- a/charts/cadence/docs/gcp/deploying-with-cloud-sql.md
+++ b/charts/cadence/docs/gcp/deploying-with-cloud-sql.md
@@ -1,0 +1,513 @@
+# Deploying Cadence on GKE with Cloud SQL for MySQL
+
+This guide provides step-by-step instructions for deploying Cadence on Google Kubernetes Engine (GKE) using Cloud SQL for MySQL as the persistence layer.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Deployment Options](#deployment-options)
+  - [Option 1: Direct Connection with Built-in Authentication](#option-1-direct-connection-with-built-in-authentication)
+  - [Option 2: Cloud SQL Proxy with Built-in Authentication (Password)](#option-2-cloud-sql-proxy-with-built-in-authentication-password)
+  - [Option 3: Cloud SQL Proxy with Built-in Authentication (No Password)](#option-3-cloud-sql-proxy-with-built-in-authentication-no-password)
+  - [Option 4: Cloud SQL Proxy with IAM Authentication](#option-4-cloud-sql-proxy-with-iam-authentication)
+- [Verification](#verification)
+- [Troubleshooting](#troubleshooting)
+
+## Prerequisites
+
+Before you begin, ensure you have:
+
+1. **GKE Cluster**: A running GKE cluster with Workload Identity enabled (required for Options 2, 3 and 4)
+2. **Cloud SQL Instance**: A Cloud SQL for MySQL instance (MySQL 8.0)
+3. **Tools Installed**:
+   - `gcloud` CLI configured with appropriate permissions
+   - `kubectl` configured to access your GKE cluster
+   - `helm` 3.x installed
+4. **GCP Permissions**:
+   - Cloud SQL Admin (to create databases and users)
+   - Kubernetes Engine Admin (to deploy to GKE)
+   - Service Account Admin (for IAM authentication setup)
+
+---
+
+## Deployment Options
+
+Choose the deployment option that best fits your security and operational requirements.
+
+### Option 1: Direct Connection with Built-in Authentication
+
+**Use case**: Simplest setup, suitable for development or when Cloud SQL Proxy overhead is not acceptable.
+
+**Architecture**: Cadence pods connect directly to Cloud SQL via private IP or public IP with authorized networks.
+
+#### Prerequisites
+
+- Cloud SQL instance has either:
+  - **Private IP** configured with VPC peering to your GKE cluster's VPC, OR
+  - **Public IP** with authorized networks configured to allow GKE node IPs
+
+#### Step 1: Create Database User
+
+Create a database user with `cloudsqlsuperuser` role using the gcloud CLI:
+
+```bash
+# Built-in users will be granted the cloudsqlsuperuser role automatically if no roles are specified.
+gcloud sql users create cadence-user \
+  --instance=YOUR-INSTANCE-NAME \
+  --host=% \
+  --password=your-strong-password
+```
+
+**Alternatively**, you can create the user from the Google Cloud Console:
+1. Go to Cloud SQL Instances → Select your instance → Users
+2. Click "Add User Account"
+3. Select "Built-in authentication"
+4. Username: `cadence-user`
+5. Password: `your-strong-password`
+6. Check "Grant this user the cloudsqlsuperuser privilege"
+7. Click "Add"
+
+**Note**: The `cloudsqlsuperuser` privilege grants the user full access to create databases and manage schemas, which is required for Cadence's schema job to create the `cadence` and `cadence_visibility` databases during deployment.
+
+#### Step 2: Get Database Connection Details
+
+```bash
+# Get the private IP (if using VPC peering)
+gcloud sql instances describe YOUR-INSTANCE-NAME --format="value(ipAddresses[0].ipAddress)"
+
+# Or get the public IP (if using authorized networks)
+gcloud sql instances describe YOUR-INSTANCE-NAME --format="value(ipAddresses[1].ipAddress)"
+```
+
+#### Step 3: Deploy Cadence
+
+```bash
+cd charts/cadence
+
+./scripts/deploy-with-cloudsql.sh \
+  -r cadence \
+  -n cadence \
+  --direct-connection \
+  -H 10.1.2.3 \
+  -u cadence-user \
+  -p your-strong-password
+```
+
+**Parameters:**
+- `-r cadence` - Helm release name
+- `-n cadence` - Kubernetes namespace
+- `--direct-connection` - Use direct database connection (no proxy)
+- `-H 10.1.2.3` - Database IP address or hostname
+- `-u cadence-user` - Database username
+- `-p your-strong-password` - Database password
+
+#### Security Notes
+
+- Store the password in a secure secret manager instead of passing it via command line
+- Use private IP with VPC peering for better security
+- If using public IP, ensure authorized networks are properly restricted
+
+---
+
+### Option 2: Cloud SQL Proxy with Built-in Authentication (Password)
+
+**Use case**: Enhanced security with Cloud SQL Proxy while using traditional password authentication.
+
+**Architecture**: Cloud SQL Proxy runs as an init container in each Cadence pod, establishing a secure tunnel to Cloud SQL.
+
+#### Step 1: Create GCP Service Account
+
+```bash
+# Set variables
+PROJECT_ID="your-gcp-project"
+GSA_NAME="cadence-cloud-sql"
+GSA_EMAIL="${GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+# Create GCP Service Account
+gcloud iam service-accounts create $GSA_NAME \
+  --display-name="Cadence Cloud SQL Proxy" \
+  --project=$PROJECT_ID
+
+# Grant Cloud SQL Client role
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:${GSA_EMAIL}" \
+  --role="roles/cloudsql.client"
+```
+
+#### Step 2: Configure Workload Identity
+
+```bash
+# Set variables
+K8S_NAMESPACE="cadence"
+KSA_NAME="cadence"  # This will be created by the Helm chart
+
+# Bind Kubernetes SA to GCP SA
+gcloud iam service-accounts add-iam-policy-binding ${GSA_EMAIL} \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="serviceAccount:${PROJECT_ID}.svc.id.goog[${K8S_NAMESPACE}/${KSA_NAME}]" \
+  --project=$PROJECT_ID
+```
+
+#### Step 3: Create Database User
+
+Follow [**Step 1 from Option 1**](#option-1-direct-connection-with-built-in-authentication) to create the database user with password.
+
+#### Step 4: Deploy Cadence
+
+```bash
+cd charts/cadence
+
+# Get instance connection name
+INSTANCE_CONNECTION=$(gcloud sql instances describe YOUR-INSTANCE-NAME --format="value(connectionName)")
+
+./scripts/deploy-with-cloudsql.sh \
+  -r cadence \
+  -n cadence \
+  -g ${GSA_EMAIL} \
+  -i ${INSTANCE_CONNECTION} \
+  -u cadence-user \
+  -p your-strong-password
+```
+
+**Parameters:**
+- `-r cadence` - Helm release name
+- `-n cadence` - Kubernetes namespace
+- `-g ${GSA_EMAIL}` - GCP Service Account email
+- `-i ${INSTANCE_CONNECTION}` - Cloud SQL instance connection name (format: `project:region:instance`)
+- `-u cadence-user` - Database username
+- `-p your-strong-password` - Database password
+
+---
+
+### Option 3: Cloud SQL Proxy with Built-in Authentication (No Password)
+
+**Use case**: Simplify credential management by using Cloud SQL Proxy with no-password MySQL authentication.
+
+**Architecture**: Cloud SQL Proxy provides secure connectivity, MySQL user has no password (authentication is based on the secure proxy connection).
+
+#### Prerequisites
+
+- Same as Option 2 (GCP Service Account and Workload Identity setup)
+
+#### Step 1: Setup GCP Service Account and Workload Identity
+
+Follow **Steps 1-2 from Option 2** to create the GCP Service Account and configure Workload Identity.
+
+#### Step 2: Create Database User (No Password)
+
+Create a database user without a password, restricted to Cloud SQL Proxy connections only:
+
+```bash
+# Create user without password, restricted to Cloud SQL Proxy, with cloudsqlsuperuser role
+gcloud sql users create cadence-user \
+  --instance=YOUR-INSTANCE-NAME \
+  --host=cloudsqlproxy~%
+```
+
+**Alternatively**, you can create the user from the Google Cloud Console:
+1. Go to Cloud SQL Instances → Select your instance → Users
+2. Click "Add User Account"
+3. Select "Built-in authentication"
+4. Username: `cadence-user`
+5. Hostname: `cloudsqlproxy~%`
+6. Leave password field empty
+7. Check "Grant this user the cloudsqlsuperuser privilege"
+8. Click "Add"
+
+**Important**: 
+- The `cloudsqlproxy~%` host pattern restricts the user to only connect via Cloud SQL Proxy
+- This provides an additional security layer - the user cannot be used for direct connections
+- The `cloudsqlsuperuser` role grants full database creation and management privileges needed for Cadence's schema job
+
+**Security Note**: This user can only connect via the Cloud SQL Proxy from authorized workloads with the correct GCP Service Account.
+
+#### Step 3: Deploy Cadence
+
+```bash
+cd charts/cadence
+
+# Get instance connection name
+INSTANCE_CONNECTION=$(gcloud sql instances describe YOUR-INSTANCE-NAME --format="value(connectionName)")
+
+./scripts/deploy-with-cloudsql.sh \
+  -r cadence \
+  -n cadence \
+  -g ${GSA_EMAIL} \
+  -i ${INSTANCE_CONNECTION} \
+  -u cadence-user
+```
+
+**Parameters:**
+- `-r cadence` - Helm release name
+- `-n cadence` - Kubernetes namespace
+- `-g ${GSA_EMAIL}` - GCP Service Account email
+- `-i ${INSTANCE_CONNECTION}` - Cloud SQL instance connection name
+- `-u cadence-user` - Database username
+- **Note**: No password parameter
+
+---
+
+### Option 4: Cloud SQL Proxy with IAM Authentication
+
+**Use case**: Highest security - leverages Google Cloud IAM for database authentication, no passwords stored anywhere.
+
+**Architecture**: Cloud SQL Proxy with IAM authentication enabled. Database user is authenticated via the GCP Service Account's IAM permissions.
+
+#### Prerequisites
+
+- Cloud SQL instance must have the **Cloud SQL IAM database authentication** flag enabled:
+
+```bash
+gcloud sql instances patch YOUR-INSTANCE-NAME \
+  --database-flags=cloudsql_iam_authentication=on
+```
+
+#### Step 1: Setup GCP Service Account and Workload Identity
+
+Follow **Steps 1-2 from Option 2** to create the GCP Service Account and configure Workload Identity.
+
+#### Step 2: Grant Cloud SQL Instance User Role
+
+```bash
+# Grant the IAM database user role to the service account
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:${GSA_EMAIL}" \
+  --role="roles/cloudsql.instanceUser"
+```
+
+#### Step 3: Create IAM Database User
+
+The database username **must match** the GCP Service Account name (the part before `@`).
+
+Create the IAM-authenticated user using gcloud:
+
+```bash
+gcloud sql users create cadence-cloud-sql@project.iam.gserviceaccount.com \
+  --instance=YOUR-INSTANCE-NAME \
+  --database-roles=cloudsqlsuperuser \
+  --type=cloud_iam_service_account
+```
+
+**Note**: The `--type=cloud_iam_service_account` flag creates a user authenticated via Cloud IAM. 
+
+**Important**: 
+- IAM users don't have passwords - authentication is done via the GCP Service Account
+- The user can only connect via Cloud SQL Proxy with the correct GCP Service Account credentials
+
+#### Step 4: Deploy Cadence
+
+```bash
+cd charts/cadence
+
+# Get instance connection name
+INSTANCE_CONNECTION=$(gcloud sql instances describe YOUR-INSTANCE-NAME --format="value(connectionName)")
+
+./scripts/deploy-with-cloudsql.sh \
+  -r cadence \
+  -n cadence \
+  -g ${GSA_EMAIL} \
+  -i ${INSTANCE_CONNECTION} \
+  --auto-iam-authn
+```
+
+**Parameters:**
+- `-r cadence` - Helm release name
+- `-n cadence` - Kubernetes namespace
+- `-g ${GSA_EMAIL}` - GCP Service Account email
+- `-i ${INSTANCE_CONNECTION}` - Cloud SQL instance connection name
+- `--auto-iam-authn` - Enable IAM authentication
+- **Note**: Username is automatically extracted from the GCP Service Account email
+
+#### Verification
+
+Verify IAM authentication is working:
+
+```bash
+# Check pod logs for successful connection
+kubectl logs -n cadence -l app.kubernetes.io/name=cadence -c cloud-sql-proxy
+
+# Should see: "Listening on 127.0.0.1:3306"
+```
+
+---
+
+## Verification
+
+After deployment, verify that Cadence is running correctly:
+
+### 1. Check Pod Status
+
+```bash
+kubectl get pods -n cadence
+
+# Expected output: All pods should be Running
+# NAME                               READY   STATUS    RESTARTS   AGE
+# cadence-frontend-xxxxxxxxx-xxxxx   1/1     Running   0          2m
+# cadence-history-xxxxxxxxx-xxxxx    1/1     Running   0          2m
+# cadence-matching-xxxxxxxxx-xxxxx   1/1     Running   0          2m
+# cadence-worker-xxxxxxxxx-xxxxx     1/1     Running   0          2m
+```
+
+### 2. Check Schema Job
+
+```bash
+kubectl get jobs -n cadence
+
+# The schema job should show COMPLETIONS: 1/1
+kubectl logs -n cadence job/cadence-schema-server
+```
+
+### 3. Verify Database Connection
+
+```bash
+# Check main container logs
+kubectl logs -n cadence -l app.kubernetes.io/component=frontend -c cadence-frontend
+
+# For Cloud SQL Proxy deployments, check proxy logs
+kubectl logs -n cadence -l app.kubernetes.io/component=frontend -c cloud-sql-proxy
+```
+
+### 4. Test Cadence CLI
+
+```bash
+# Port-forward to frontend service
+kubectl port-forward -n cadence svc/cadence-frontend 7933:7933
+
+# In another terminal, register a domain
+docker run --network=host --rm ubercadence/cli:master \
+  --address localhost:7933 \
+  domain register --global_domain false cadence-test
+
+# List domains
+docker run --network=host --rm ubercadence/cli:master \
+  --address localhost:7933 \
+  domain list
+```
+
+---
+
+## Troubleshooting
+
+### Cloud SQL Proxy Connection Issues
+
+**Problem**: Schema job or pods stuck with "MySQL is not ready yet..."
+
+**Solution**: Check Cloud SQL Proxy logs for detailed error messages:
+
+```bash
+# Check init container logs (schema job)
+kubectl logs -n cadence job/cadence-schema-server -c cloud-sql-proxy
+
+# Check deployment init container logs
+kubectl logs -n cadence -l app.kubernetes.io/name=cadence -c cloud-sql-proxy
+```
+
+**Common errors:**
+
+1. **"failed to refresh token"**
+   - Workload Identity not configured correctly
+   - Verify: `gcloud iam service-accounts get-iam-policy ${GSA_EMAIL}`
+
+2. **"connection refused"**
+   - Instance connection name is incorrect
+   - Verify: `gcloud sql instances describe YOUR-INSTANCE-NAME --format="value(connectionName)"`
+
+3. **"Access denied for user"**
+   - Database user doesn't exist or lacks permissions
+   - Verify user: `SELECT User, Host FROM mysql.user WHERE User = 'your-user';`
+
+### IAM Authentication Issues
+
+**Problem**: Connection fails with IAM authentication enabled
+
+**Checklist**:
+1. Cloud SQL instance has `cloudsql_iam_authentication=on` flag
+2. GCP Service Account has `roles/cloudsql.instanceUser` role
+3. Database username matches GCP Service Account name (part before `@`)
+4. User was created with: `IDENTIFIED WITH caching_sha2_password AS 'cloudsqliam'`
+
+**Verify IAM user:**
+```sql
+SELECT User, Host, plugin FROM mysql.user WHERE User = 'cadence-cloud-sql';
+-- plugin should be: caching_sha2_password
+```
+
+### Direct Connection Issues
+
+**Problem**: Cannot connect to database via direct connection
+
+**Solutions**:
+
+1. **Private IP**: Verify VPC peering
+   ```bash
+   gcloud compute networks peerings list --network=YOUR-VPC-NETWORK
+   ```
+
+2. **Public IP**: Check authorized networks
+   ```bash
+   # Get your GKE node IPs
+   kubectl get nodes -o wide
+   
+   # Verify they're in authorized networks
+   gcloud sql instances describe YOUR-INSTANCE-NAME --format="value(settings.ipConfiguration.authorizedNetworks)"
+   ```
+
+### Schema Migration Failures
+
+**Problem**: Schema job fails to complete
+
+**Debug**:
+```bash
+# View detailed schema job logs
+kubectl logs -n cadence job/cadence-schema-server -c wait-for-database
+
+# Check MySQL connection from schema job
+kubectl logs -n cadence job/cadence-schema-server -c cadence-sql-tool
+```
+
+**Common issues**:
+- Database doesn't exist - Create `cadence` and `cadence_visibility` databases
+- User lacks permissions - Grant ALL PRIVILEGES on both databases
+- Wrong database driver - Ensure `config.persistence.database.driver: mysql` in values
+
+### Performance Tuning
+
+For production deployments:
+
+1. **Cloud SQL Proxy resources**: Adjust if experiencing connection issues
+   ```yaml
+   cloudSqlProxy:
+     resources:
+       requests:
+         cpu: 200m
+         memory: 256Mi
+       limits:
+         cpu: 500m
+         memory: 512Mi
+   ```
+
+2. **Database connection pool**: Tune based on workload
+   ```yaml
+   config:
+     persistence:
+       database:
+         sql:
+           maxConns: 50
+           maxIdleConns: 20
+   ```
+
+3. **Cloud SQL instance size**: Scale based on Cadence workload
+   ```bash
+   gcloud sql instances patch YOUR-INSTANCE-NAME \
+     --tier=db-n1-standard-2 \
+     --database-flags=max_connections=1000
+   ```
+
+---
+
+## References
+
+- [Cloud SQL Proxy Documentation](https://cloud.google.com/sql/docs/mysql/sql-proxy)
+- [Cloud SQL IAM Authentication](https://cloud.google.com/sql/docs/mysql/authentication)
+- [GKE Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
+- [Cadence Documentation](https://cadenceworkflow.io/docs/)

--- a/charts/cadence/docs/gcp/deploying-with-cloud-sql.md
+++ b/charts/cadence/docs/gcp/deploying-with-cloud-sql.md
@@ -73,10 +73,10 @@ gcloud sql users create cadence-user \
 
 ```bash
 # Get the private IP (if using VPC peering)
-gcloud sql instances describe YOUR-INSTANCE-NAME --format="value(ipAddresses[0].ipAddress)"
+gcloud sql instances describe YOUR-INSTANCE-NAME --format=json | jq -r '.ipAddresses[] | select(.type=="PRIVATE") | .ipAddress'
 
 # Or get the public IP (if using authorized networks)
-gcloud sql instances describe YOUR-INSTANCE-NAME --format="value(ipAddresses[1].ipAddress)"
+gcloud sql instances describe YOUR-INSTANCE-NAME --format=json | jq -r '.ipAddresses[] | select(.type=="PUBLIC") | .ipAddress'
 ```
 
 #### Step 3: Deploy Cadence

--- a/charts/cadence/examples/values.mysql-cloudsql.yaml
+++ b/charts/cadence/examples/values.mysql-cloudsql.yaml
@@ -1,0 +1,71 @@
+# Example: Cadence with Cloud SQL for MySQL via Cloud SQL Proxy
+#
+# This example demonstrates:
+# - Cloud SQL Proxy sidecar for secure database connection
+# - GKE Workload Identity for authentication
+# - MySQL as the primary database and the visibility database
+# - No subcharts (using external Cloud SQL instance)
+
+# Service Account with Workload Identity annotation
+serviceAccount:
+  create: true
+  name: "cadence"
+  # Add GKE Workload Identity annotation to bind K8s SA to GCP SA
+  annotations:
+    # reference: https://docs.cloud.google.com/sql/docs/mysql/connect-kubernetes-engine#workload-identity
+    iam.gke.io/gcp-service-account: ""
+
+# Cloud SQL Proxy configuration
+cloudSqlProxy:
+  # Enable Cloud SQL Proxy sidecar
+  enabled: true
+  # Cloud SQL instance connection name (format: projectID:region:instance)
+  instanceConnectionName: ""
+  # Port for the proxy to listen on
+  port: 3306
+  # Use private IP (requires VPC peering with Cloud SQL)
+  privateIp: true
+  # Enable automatic IAM authentication (no database password needed)
+  # Requires GKE Workload Identity and proper IAM permissions
+  autoIamAuthn: true 
+  # Optional: additional arguments for fine-tuning
+  #extraArgs:
+  #  - "--max-connections=100"
+  #  - "--max-sigterm-delay=30s"
+
+# Cadence configuration
+config:
+  persistence:
+    database:
+      driver: "mysql"
+      sql:
+        # Connect to localhost since Cloud SQL Proxy runs as a sidecar
+        hosts: "127.0.0.1"
+        user: "cadence"
+        # Password can be empty when using Cloud SQL IAM authentication
+        # or set it if using database authentication
+        password: ""
+        tls:
+          enabled: false
+          sslMode: ""
+      mysql:
+        port: 3306
+
+# Enable schema job
+schema:
+  serverJob:
+    enabled: true
+
+# Disable all database subcharts (using Cloud SQL)
+postgresql:
+  enabled: false
+mysql:
+  enabled: false
+cassandra:
+  enabled: false
+elasticsearch:
+  enabled: false
+opensearch:
+  enabled: false
+kafka:
+  enabled: false

--- a/charts/cadence/examples/values.mysql-cloudsql.yaml
+++ b/charts/cadence/examples/values.mysql-cloudsql.yaml
@@ -1,7 +1,7 @@
 # Example: Cadence with Cloud SQL for MySQL via Cloud SQL Proxy
 #
 # This example demonstrates:
-# - Cloud SQL Proxy sidecar for secure database connection
+# - Cloud SQL Proxy as native sidecar init container for secure database connection
 # - GKE Workload Identity for authentication
 # - MySQL as the primary database and the visibility database
 # - No subcharts (using external Cloud SQL instance)
@@ -17,21 +17,30 @@ serviceAccount:
 
 # Cloud SQL Proxy configuration
 cloudSqlProxy:
-  # Enable Cloud SQL Proxy sidecar
+  # Enable Cloud SQL Proxy init container
   enabled: true
-  # Cloud SQL instance connection name (format: projectID:region:instance)
-  instanceConnectionName: ""
-  # Port for the proxy to listen on
-  port: 3306
-  # Use private IP (requires VPC peering with Cloud SQL)
-  privateIp: true
-  # Enable automatic IAM authentication (no database password needed)
-  # Requires GKE Workload Identity and proper IAM permissions
-  autoIamAuthn: true 
-  # Optional: additional arguments for fine-tuning
-  #extraArgs:
-  #  - "--max-connections=100"
-  #  - "--max-sigterm-delay=30s"
+
+  # Init container specification (native sidecar pattern with restartPolicy: Always)
+  initContainer:
+    name: cloud-sql-proxy
+    restartPolicy: Always  # Required for native sidecar (K8s 1.29+)
+    image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1
+    imagePullPolicy: IfNotPresent
+    args:
+      - "PROJECT:REGION:INSTANCE"  # Replace with your instance connection name
+      - "--port=3306"
+      - "--private-ip"           # Use private IP (requires VPC peering)
+      # --auto-iam-authn is controlled by the deployment script via --auto-iam-authn flag
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+    securityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
 
 # Cadence configuration
 config:

--- a/charts/cadence/examples/values.mysql.yaml
+++ b/charts/cadence/examples/values.mysql.yaml
@@ -1,0 +1,35 @@
+# Force Cadence to use PostgreSQL for main DB
+config:
+  persistence:
+    database:
+      driver: "mysql"
+      sql:
+        # Hostname auto-generated as {release-name}-postgresql.{namespace}.svc.cluster.local
+        # when postgresql.enabled=true. Set explicitly for external PostgreSQL.
+        hosts: ""
+        user: "cadence"
+        password: "changeme-strong"
+        tls:
+          enabled: false
+          sslMode: ""
+      mysql:
+        port: 3306
+
+# Enable Cadence schema jobs
+schema:
+  serverJob:
+    enabled: true
+
+# Do NOT deploy ES, Kafka, Cassandra or MySQL
+elasticsearch:
+  enabled: false
+opensearch:
+  enabled: false
+kafka:
+  enabled: false
+cassandra:
+  enabled: false
+mysql:
+  enabled: false
+postgresql:
+  enabled: false

--- a/charts/cadence/scripts/deploy-with-cloudsql.sh
+++ b/charts/cadence/scripts/deploy-with-cloudsql.sh
@@ -229,30 +229,34 @@ else
 fi
 echo ""
 
-# Build Helm command
-HELM_CMD="helm upgrade --install $RELEASE_NAME $CHART_PATH \
-  --namespace $NAMESPACE \
-  --values $CHART_PATH/$VALUES_FILE \
-  --set config.persistence.database.sql.user=$DB_USER \
-  --create-namespace"
+# Build Helm command as an array (safer than string concatenation + eval)
+helm_args=(
+  upgrade --install "$RELEASE_NAME" "$CHART_PATH"
+  --namespace "$NAMESPACE"
+  --values "$CHART_PATH/$VALUES_FILE"
+  --set "config.persistence.database.sql.user=$DB_USER"
+  --create-namespace
+)
 
 if [ "$DIRECT_CONNECTION" = "true" ]; then
     # Direct connection mode
-    HELM_CMD="$HELM_CMD \
-      --set cloudSqlProxy.enabled=false \
-      --set config.persistence.database.sql.hosts=$DB_HOST \
-      --set config.persistence.database.mysql.port=$DB_PORT"
+    helm_args+=(
+      --set cloudSqlProxy.enabled=false
+      --set "config.persistence.database.sql.hosts=$DB_HOST"
+      --set "config.persistence.database.mysql.port=$DB_PORT"
+    )
 else
     # Cloud SQL Proxy mode
-    HELM_CMD="$HELM_CMD \
-      --set-string 'serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account=$GCP_SA' \
-      --set cloudSqlProxy.instanceConnectionName=$INSTANCE_CONNECTION \
-      --set cloudSqlProxy.autoIamAuthn=$AUTO_IAM_AUTHN"
+    helm_args+=(
+      --set-string "serviceAccount.annotations.iam\.gke\.io/gcp-service-account=$GCP_SA"
+      --set "cloudSqlProxy.instanceConnectionName=$INSTANCE_CONNECTION"
+      --set "cloudSqlProxy.autoIamAuthn=$AUTO_IAM_AUTHN"
+    )
 fi
 
-# Add password if provided
+# Add password if provided (use --set-string to avoid type conversion issues)
 if [ -n "$PASSWORD" ]; then
-    HELM_CMD="$HELM_CMD --set config.persistence.database.sql.password=$PASSWORD"
+    helm_args+=(--set-string "config.persistence.database.sql.password=$PASSWORD")
 fi
 
 # Print or execute Helm command
@@ -262,7 +266,10 @@ if [ "$DRY_RUN" = "true" ]; then
     echo "DRY-RUN MODE - Command to be executed:"
     echo "=========================================="
     echo ""
-    echo "$HELM_CMD"
+    # Print the command in a readable format
+    printf "helm"
+    printf " %q" "${helm_args[@]}"
+    echo ""
     echo ""
     echo "=========================================="
     echo ""
@@ -271,7 +278,7 @@ if [ "$DRY_RUN" = "true" ]; then
 fi
 
 # Execute deployment
-eval $HELM_CMD
+helm "${helm_args[@]}"
 
 echo ""
 echo "Deployment complete! Check status with:"

--- a/charts/cadence/scripts/deploy-with-cloudsql.sh
+++ b/charts/cadence/scripts/deploy-with-cloudsql.sh
@@ -1,0 +1,304 @@
+#!/bin/bash
+# Simple deployment script for Cadence with Cloud SQL Proxy or direct connection
+
+set -e
+
+# Default values
+AUTO_IAM_AUTHN="false"
+DIRECT_CONNECTION="false"
+PASSWORD=""
+DB_USER=""
+DB_HOST=""
+DB_PORT="3306"
+CHART_PATH="./"
+VALUES_FILE=""
+DRY_RUN="false"
+
+# Function to show usage
+usage() {
+    cat << EOF
+Usage: $0 -r <release-name> -n <namespace> [CONNECTION OPTIONS] [AUTH OPTIONS]
+
+Required arguments:
+  -r, --release-name NAME        Helm release name
+  -n, --namespace NAMESPACE      Kubernetes namespace
+
+Connection options (choose one):
+  Cloud SQL Proxy (default):
+    -g, --gcp-sa EMAIL            GCP Service Account email
+    -i, --instance CONNECTION     Cloud SQL instance connection (format: project:region:instance)
+    --auto-iam-authn              Enable Cloud SQL IAM authentication
+
+  Direct connection:
+    --direct-connection           Use direct database connection (no Cloud SQL Proxy)
+    -H, --hostname HOST          Database hostname or IP address
+    -P, --port PORT              Database port (default: 3306)
+
+Authentication options:
+  -u, --db-user USER            Database username (required for built-in auth, auto-extracted for IAM auth)
+  -p, --password PASSWORD       Database password (for built-in auth only)
+
+Other options:
+  -c, --chart-path PATH         Path to Helm chart (default: ./)
+  -v, --values-file FILE        Values file (default: auto-selected based on connection type)
+                                  - Direct connection: examples/values.mysql.yaml
+                                  - Cloud SQL Proxy: examples/values.mysql-cloudsql.yaml
+  --dry-run                     Print the Helm command without executing it
+  -h, --help                    Show this help message
+
+Examples:
+  # Cloud SQL Proxy with IAM authentication
+  $0 -r cadence -n my-namespace -g cadence@project.iam.gserviceaccount.com -i project:region:instance --auto-iam-authn
+
+  # Cloud SQL Proxy with built-in authentication
+  $0 -r cadence -n my-namespace -g cadence@project.iam.gserviceaccount.com -i project:region:instance -u myuser -p mypassword
+
+  # Direct connection with built-in authentication
+  $0 -r cadence -n my-namespace --direct-connection -H 10.1.2.3 -u myuser -p mypassword
+
+  # Direct connection with hostname and custom port
+  $0 -r cadence -n my-namespace --direct-connection -H mysql.example.com -P 3307 -u myuser -p mypassword
+
+  # Dry-run mode (print command without executing)
+  $0 -r cadence -n my-namespace -g cadence@project.iam.gserviceaccount.com -i project:region:instance --auto-iam-authn --dry-run
+
+EOF
+    exit 1
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -r|--release-name)
+            RELEASE_NAME="$2"
+            shift 2
+            ;;
+        -n|--namespace)
+            NAMESPACE="$2"
+            shift 2
+            ;;
+        -g|--gcp-sa)
+            GCP_SA="$2"
+            shift 2
+            ;;
+        -i|--instance)
+            INSTANCE_CONNECTION="$2"
+            shift 2
+            ;;
+        -u|--db-user)
+            DB_USER="$2"
+            shift 2
+            ;;
+        -p|--password)
+            PASSWORD="$2"
+            shift 2
+            ;;
+        -H|--hostname)
+            DB_HOST="$2"
+            shift 2
+            ;;
+        -P|--port)
+            DB_PORT="$2"
+            shift 2
+            ;;
+        --auto-iam-authn)
+            AUTO_IAM_AUTHN="true"
+            shift
+            ;;
+        --direct-connection)
+            DIRECT_CONNECTION="true"
+            shift
+            ;;
+        -c|--chart-path)
+            CHART_PATH="$2"
+            shift 2
+            ;;
+        -v|--values-file)
+            VALUES_FILE="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN="true"
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Error: Unknown option $1"
+            usage
+            ;;
+    esac
+done
+
+# Validate required arguments
+if [ -z "$RELEASE_NAME" ]; then
+    echo "Error: Release name is required (-r/--release-name)"
+    usage
+fi
+
+if [ -z "$NAMESPACE" ]; then
+    echo "Error: Namespace is required (-n/--namespace)"
+    usage
+fi
+
+# Validate connection options
+if [ "$DIRECT_CONNECTION" = "true" ]; then
+    # Direct connection validation
+    if [ -z "$DB_HOST" ]; then
+        echo "Error: Database hostname is required for direct connection (-H/--hostname)"
+        usage
+    fi
+
+    # Cannot use Cloud SQL Proxy options with direct connection
+    if [ -n "$GCP_SA" ] || [ -n "$INSTANCE_CONNECTION" ]; then
+        echo "Error: Cannot use Cloud SQL Proxy options (-g/-i) with --direct-connection"
+        usage
+    fi
+
+    # Cannot use IAM auth with direct connection
+    if [ "$AUTO_IAM_AUTHN" = "true" ]; then
+        echo "Error: Cannot use --auto-iam-authn with --direct-connection"
+        usage
+    fi
+else
+    # Cloud SQL Proxy validation
+    if [ -z "$GCP_SA" ]; then
+        echo "Error: GCP Service Account is required for Cloud SQL Proxy (-g/--gcp-sa)"
+        usage
+    fi
+
+    if [ -z "$INSTANCE_CONNECTION" ]; then
+        echo "Error: Instance connection is required for Cloud SQL Proxy (-i/--instance)"
+        usage
+    fi
+
+    # Cannot use hostname/port with Cloud SQL Proxy
+    if [ -n "$DB_HOST" ]; then
+        echo "Error: Cannot use --hostname with Cloud SQL Proxy (use --direct-connection)"
+        usage
+    fi
+fi
+
+# Validate: cannot use password with IAM auth
+if [ "$AUTO_IAM_AUTHN" = "true" ] && [ -n "$PASSWORD" ]; then
+    echo "Error: Cannot use password with --auto-iam-authn flag"
+    exit 1
+fi
+
+# Handle database username
+if [ -z "$DB_USER" ]; then
+    if [ "$AUTO_IAM_AUTHN" = "true" ]; then
+        # For IAM auth, auto-extract from GCP SA email
+        DB_USER=$(echo "$GCP_SA" | cut -d@ -f1)
+        echo "Database username not provided, using: $DB_USER (extracted from GCP SA for IAM auth)"
+    else
+        # For built-in auth, username is required
+        echo "Error: Database username is required for built-in authentication (-u/--db-user)"
+        usage
+    fi
+fi
+
+# Set default values file based on connection type
+if [ -z "$VALUES_FILE" ]; then
+    if [ "$DIRECT_CONNECTION" = "true" ]; then
+        VALUES_FILE="examples/values.mysql.yaml"
+    else
+        VALUES_FILE="examples/values.mysql-cloudsql.yaml"
+    fi
+fi
+
+# Display configuration
+if [ "$DIRECT_CONNECTION" = "true" ]; then
+    echo "Deploying Cadence with direct database connection:"
+    echo "  Release:   $RELEASE_NAME"
+    echo "  Namespace: $NAMESPACE"
+    echo "  DB Host:   $DB_HOST"
+    echo "  DB Port:   $DB_PORT"
+    echo "  DB User:   $DB_USER"
+    echo "  Password:  $([ -n "$PASSWORD" ] && echo 'yes' || echo 'no')"
+else
+    echo "Deploying Cadence with Cloud SQL Proxy:"
+    echo "  Release:   $RELEASE_NAME"
+    echo "  Namespace: $NAMESPACE"
+    echo "  GCP SA:    $GCP_SA"
+    echo "  Instance:  $INSTANCE_CONNECTION"
+    echo "  DB User:   $DB_USER"
+    echo "  Password:  $([ -n "$PASSWORD" ] && echo 'yes' || echo 'no')"
+    echo "  Auth Mode: $([ "$AUTO_IAM_AUTHN" = "true" ] && echo 'IAM' || echo 'Built-in MySQL')"
+fi
+echo ""
+
+# Build Helm command
+HELM_CMD="helm upgrade --install $RELEASE_NAME $CHART_PATH \
+  --namespace $NAMESPACE \
+  --values $CHART_PATH/$VALUES_FILE \
+  --set config.persistence.database.sql.user=$DB_USER \
+  --create-namespace"
+
+if [ "$DIRECT_CONNECTION" = "true" ]; then
+    # Direct connection mode
+    HELM_CMD="$HELM_CMD \
+      --set cloudSqlProxy.enabled=false \
+      --set config.persistence.database.sql.hosts=$DB_HOST \
+      --set config.persistence.database.mysql.port=$DB_PORT"
+else
+    # Cloud SQL Proxy mode
+    HELM_CMD="$HELM_CMD \
+      --set-string 'serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account=$GCP_SA' \
+      --set cloudSqlProxy.instanceConnectionName=$INSTANCE_CONNECTION \
+      --set cloudSqlProxy.autoIamAuthn=$AUTO_IAM_AUTHN"
+fi
+
+# Add password if provided
+if [ -n "$PASSWORD" ]; then
+    HELM_CMD="$HELM_CMD --set config.persistence.database.sql.password=$PASSWORD"
+fi
+
+# Print or execute Helm command
+if [ "$DRY_RUN" = "true" ]; then
+    echo ""
+    echo "=========================================="
+    echo "DRY-RUN MODE - Command to be executed:"
+    echo "=========================================="
+    echo ""
+    echo "$HELM_CMD"
+    echo ""
+    echo "=========================================="
+    echo ""
+    echo "Note: This command was NOT executed. Remove --dry-run to actually deploy."
+    exit 0
+fi
+
+# Execute deployment
+eval $HELM_CMD
+
+echo ""
+echo "Deployment complete! Check status with:"
+echo "  kubectl get pods -n $NAMESPACE"
+echo "  helm status $RELEASE_NAME -n $NAMESPACE"
+echo ""
+
+if [ "$DIRECT_CONNECTION" = "true" ]; then
+    echo "Direct database connection is enabled. Ensure:"
+    echo "  1. Database server '$DB_HOST:$DB_PORT' is accessible from the cluster"
+    echo "  2. Database user '$DB_USER' exists and has appropriate privileges"
+    if [ -z "$PASSWORD" ]; then
+        echo "  3. User is configured for no-password authentication"
+    fi
+else
+    if [ "$AUTO_IAM_AUTHN" = "true" ]; then
+        echo "IAM Authentication is enabled. Ensure:"
+        echo "  1. GCP Service Account '$GCP_SA' has 'Cloud SQL Client' and 'Cloud SQL Instance User' roles"
+        echo "  2. Database user is created with IAM authentication and has 'cloudsqlsuperuser' role:"
+        echo "     gcloud sql users create '$DB_USER' --instance=YOUR-INSTANCE-NAME --database-roles=cloudsqlsuperuser --type=cloud_iam_service_account"
+    else
+        echo "Built-in MySQL authentication is enabled. Ensure:"
+        echo "  1. Database user '$DB_USER' exists in Cloud SQL"
+        echo "  2. User has privileges on cadence and cadence_visibility databases"
+        if [ -z "$PASSWORD" ]; then
+            echo "  3. User is configured for no-password authentication"
+        fi
+    fi
+fi
+

--- a/charts/cadence/scripts/deploy-with-cloudsql.sh
+++ b/charts/cadence/scripts/deploy-with-cloudsql.sh
@@ -246,12 +246,18 @@ if [ "$DIRECT_CONNECTION" = "true" ]; then
       --set "config.persistence.database.mysql.port=$DB_PORT"
     )
 else
-    # Cloud SQL Proxy mode
+    # Cloud SQL Proxy mode - always use private IP
     helm_args+=(
       --set-string "serviceAccount.annotations.iam\.gke\.io/gcp-service-account=$GCP_SA"
-      --set "cloudSqlProxy.instanceConnectionName=$INSTANCE_CONNECTION"
-      --set "cloudSqlProxy.autoIamAuthn=$AUTO_IAM_AUTHN"
+      --set "cloudSqlProxy.initContainer.args[0]=$INSTANCE_CONNECTION"
+      --set "cloudSqlProxy.initContainer.args[1]=--port=3306"
+      --set "cloudSqlProxy.initContainer.args[2]=--private-ip"
     )
+
+    # Add --auto-iam-authn if enabled
+    if [ "$AUTO_IAM_AUTHN" = "true" ]; then
+        helm_args+=(--set "cloudSqlProxy.initContainer.args[3]=--auto-iam-authn")
+    fi
 fi
 
 # Add password if provided (use --set-string to avoid type conversion issues)

--- a/charts/cadence/templates/schema-server-job.yaml
+++ b/charts/cadence/templates/schema-server-job.yaml
@@ -46,30 +46,8 @@ spec:
       {{- end }}
       restartPolicy: OnFailure
       initContainers:
-      {{- if and $.Values.cloudSqlProxy.enabled (or (eq $dbDriver "postgres") (eq $dbDriver "mysql")) }}
-      - name: cloud-sql-proxy
-        restartPolicy: Always
-        image: {{ $.Values.cloudSqlProxy.image.repository }}:{{ $.Values.cloudSqlProxy.image.tag }}
-        imagePullPolicy: {{ $.Values.cloudSqlProxy.image.pullPolicy }}
-        args:
-          - "--port={{ $.Values.cloudSqlProxy.port }}"
-          {{- if $.Values.cloudSqlProxy.privateIp }}
-          - "--private-ip"
-          {{- end }}
-          {{- if $.Values.cloudSqlProxy.autoIamAuthn }}
-          - "--auto-iam-authn"
-          {{- end }}
-          - "{{ $.Values.cloudSqlProxy.instanceConnectionName }}"
-          {{- range $.Values.cloudSqlProxy.extraArgs }}
-          - {{ . | quote }}
-          {{- end }}
-        {{- with $.Values.cloudSqlProxy.resources }}
-        resources:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        securityContext:
-          runAsNonRoot: true
-          allowPrivilegeEscalation: false
+      {{- if and $.Values.cloudSqlProxy.enabled $.Values.cloudSqlProxy.initContainer }}
+      - {{- toYaml $.Values.cloudSqlProxy.initContainer | nindent 8 }}
       {{- end }}
       - name: wait-for-database
         {{- if eq $dbDriver "cassandra" }}

--- a/charts/cadence/templates/schema-server-job.yaml
+++ b/charts/cadence/templates/schema-server-job.yaml
@@ -46,6 +46,31 @@ spec:
       {{- end }}
       restartPolicy: OnFailure
       initContainers:
+      {{- if and $.Values.cloudSqlProxy.enabled (or (eq $dbDriver "postgres") (eq $dbDriver "mysql")) }}
+      - name: cloud-sql-proxy
+        restartPolicy: Always
+        image: {{ $.Values.cloudSqlProxy.image.repository }}:{{ $.Values.cloudSqlProxy.image.tag }}
+        imagePullPolicy: {{ $.Values.cloudSqlProxy.image.pullPolicy }}
+        args:
+          - "--port={{ $.Values.cloudSqlProxy.port }}"
+          {{- if $.Values.cloudSqlProxy.privateIp }}
+          - "--private-ip"
+          {{- end }}
+          {{- if $.Values.cloudSqlProxy.autoIamAuthn }}
+          - "--auto-iam-authn"
+          {{- end }}
+          - "{{ $.Values.cloudSqlProxy.instanceConnectionName }}"
+          {{- range $.Values.cloudSqlProxy.extraArgs }}
+          - {{ . | quote }}
+          {{- end }}
+        {{- with $.Values.cloudSqlProxy.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+      {{- end }}
       - name: wait-for-database
         {{- if eq $dbDriver "cassandra" }}
         image: {{ $.Values.schema.checkSchema.cassandra.image.repository }}:{{ $.Values.schema.checkSchema.cassandra.image.tag }}
@@ -247,11 +272,13 @@ spec:
         - name: DB_USER
           value: {{ $.Values.config.persistence.database.sql.user | quote }}
         # Authentication parameters
+        {{- if $.Values.config.persistence.database.sql.password }}
         - name: POSTGRES_PWD
           valueFrom:
             secretKeyRef:
               name: {{ include "cadence.fullname" $ }}-frontend-secrets
               key: POSTGRES_PWD
+        {{- end }}
         # TLS Configuration
         - name: TLS_ENABLED
           value: {{ $.Values.config.persistence.database.sql.tls.enabled | quote }}
@@ -287,7 +314,12 @@ spec:
           - |
             # Build connection string based on TLS configuration
             build_mysql_cmd() {
-              local cmd="mariadb -h $DB_HOST -P $DB_PORT -u $DB_USER -p$MYSQL_PWD"
+              local cmd="mariadb -h $DB_HOST -P $DB_PORT -u $DB_USER"
+
+              # Add password if provided (not using IAM auth)
+              if [ -n "$MYSQL_PWD" ]; then
+                cmd="$cmd -p$MYSQL_PWD"
+              fi
 
               # Add SSL parameters if TLS is enabled
               if [ "$TLS_ENABLED" = "true" ]; then
@@ -332,8 +364,20 @@ spec:
 
             # Wait for MySQL to be ready
             echo "Waiting for MySQL to be ready..."
-            until $(build_mysql_cmd) -e "SELECT 1" >/dev/null 2>&1; do
-              echo 'MySQL is not ready yet...'
+            echo "Connection details:"
+            echo "  Host: $DB_HOST"
+            echo "  Port: $DB_PORT"
+            echo "  User: $DB_USER"
+            echo "  Using password: $([ -n "$MYSQL_PWD" ] && echo 'yes' || echo 'no (IAM auth)')"
+            echo "  TLS enabled: $TLS_ENABLED"
+            echo ""
+            echo "Testing connection with command:"
+            build_mysql_cmd
+            echo ""
+
+            until $(build_mysql_cmd) -e "SELECT 1" 2>&1; do
+              echo "[$(date '+%Y-%m-%d %H:%M:%S')] MySQL is not ready yet... (connection attempt failed)"
+              echo "Last error output shown above"
               sleep 5
             done
             echo "MySQL is ready!"
@@ -352,11 +396,13 @@ spec:
         - name: DB_USER
           value: {{ $.Values.config.persistence.database.sql.user | quote }}
         # Authentication parameters
+        {{- if $.Values.config.persistence.database.sql.password }}
         - name: MYSQL_PWD
           valueFrom:
             secretKeyRef:
               name: {{ include "cadence.fullname" $ }}-frontend-secrets
               key: MYSQL_PWD
+        {{- end }}
         # TLS Configuration
         - name: TLS_ENABLED
           value: {{ $.Values.config.persistence.database.sql.tls.enabled | quote }}
@@ -615,11 +661,13 @@ spec:
         - name: DB_USER
           value: {{ .Values.config.persistence.database.sql.user | quote }}
         # Authentication parameters
+        {{- if $.Values.config.persistence.database.sql.password }}
         - name: POSTGRES_PWD
           valueFrom:
             secretKeyRef:
               name: {{ include "cadence.fullname" $ }}-frontend-secrets
               key: POSTGRES_PWD
+        {{- end }}
         # TLS Configuration
         - name: TLS_ENABLED
           value: {{ .Values.config.persistence.database.sql.tls.enabled | quote }}
@@ -720,11 +768,13 @@ spec:
         - name: DB_USER
           value: {{ .Values.config.persistence.database.sql.user | quote }}
         # Authentication parameters
+        {{- if $.Values.config.persistence.database.sql.password }}
         - name: MYSQL_PWD
           valueFrom:
             secretKeyRef:
               name: {{ include "cadence.fullname" $ }}-frontend-secrets
               key: MYSQL_PWD
+        {{- end }}
         # TLS Configuration
         - name: TLS_ENABLED
           value: {{ .Values.config.persistence.database.sql.tls.enabled | quote }}

--- a/charts/cadence/templates/schema-server-job.yaml
+++ b/charts/cadence/templates/schema-server-job.yaml
@@ -371,9 +371,6 @@ spec:
             echo "  Using password: $([ -n "$MYSQL_PWD" ] && echo 'yes' || echo 'no (IAM auth)')"
             echo "  TLS enabled: $TLS_ENABLED"
             echo ""
-            echo "Testing connection with command:"
-            build_mysql_cmd
-            echo ""
 
             until $(build_mysql_cmd) -e "SELECT 1" 2>&1; do
               echo "[$(date '+%Y-%m-%d %H:%M:%S')] MySQL is not ready yet... (connection attempt failed)"

--- a/charts/cadence/templates/server-configmap.yaml
+++ b/charts/cadence/templates/server-configmap.yaml
@@ -137,20 +137,12 @@ data:
           sql:
             {{- if eq .Values.config.persistence.database.driver "mysql" }}
             pluginName: "mysql"
-            {{- if .Values.cloudSqlProxy.enabled }}
-            connectAddr: "127.0.0.1:{{ .Values.cloudSqlProxy.port }}"
-            {{- else }}
             {{- $port := .Values.config.persistence.database.mysql.port | default .Values.config.persistence.database.sql.port | default 3306 }}
             connectAddr: "{{ include "cadence.sqlHost" . }}:{{ $port }}"
-            {{- end }}
             {{- else if eq .Values.config.persistence.database.driver "postgres" }}
             pluginName: "postgres"
-            {{- if .Values.cloudSqlProxy.enabled }}
-            connectAddr: "127.0.0.1:{{ .Values.cloudSqlProxy.port }}"
-            {{- else }}
             {{- $port := .Values.config.persistence.database.postgres.port | default .Values.config.persistence.database.sql.port | default 5432 }}
             connectAddr: "{{ include "cadence.sqlHost" . }}:{{ $port }}"
-            {{- end }}
             {{- end }}
             connectProtocol: "tcp"
             databaseName: {{ .Values.config.persistence.database.sql.dbname | default "cadence" | quote }}

--- a/charts/cadence/templates/server-configmap.yaml
+++ b/charts/cadence/templates/server-configmap.yaml
@@ -137,12 +137,20 @@ data:
           sql:
             {{- if eq .Values.config.persistence.database.driver "mysql" }}
             pluginName: "mysql"
+            {{- if .Values.cloudSqlProxy.enabled }}
+            connectAddr: "127.0.0.1:{{ .Values.cloudSqlProxy.port }}"
+            {{- else }}
             {{- $port := .Values.config.persistence.database.mysql.port | default .Values.config.persistence.database.sql.port | default 3306 }}
             connectAddr: "{{ include "cadence.sqlHost" . }}:{{ $port }}"
+            {{- end }}
             {{- else if eq .Values.config.persistence.database.driver "postgres" }}
             pluginName: "postgres"
+            {{- if .Values.cloudSqlProxy.enabled }}
+            connectAddr: "127.0.0.1:{{ .Values.cloudSqlProxy.port }}"
+            {{- else }}
             {{- $port := .Values.config.persistence.database.postgres.port | default .Values.config.persistence.database.sql.port | default 5432 }}
             connectAddr: "{{ include "cadence.sqlHost" . }}:{{ $port }}"
+            {{- end }}
             {{- end }}
             connectProtocol: "tcp"
             databaseName: {{ .Values.config.persistence.database.sql.dbname | default "cadence" | quote }}

--- a/charts/cadence/templates/server-deployment.yaml
+++ b/charts/cadence/templates/server-deployment.yaml
@@ -78,30 +78,8 @@ spec:
         {{- toYaml $serviceTopologySpreadConstraints | nindent 8 }}
       {{- end }}
       initContainers:
-      {{- if and $.Values.cloudSqlProxy.enabled (or (eq $.Values.config.persistence.database.driver "postgres") (eq $.Values.config.persistence.database.driver "mysql")) }}
-      - name: cloud-sql-proxy
-        restartPolicy: Always
-        image: {{ $.Values.cloudSqlProxy.image.repository }}:{{ $.Values.cloudSqlProxy.image.tag }}
-        imagePullPolicy: {{ $.Values.cloudSqlProxy.image.pullPolicy }}
-        args:
-          - "--port={{ $.Values.cloudSqlProxy.port }}"
-          {{- if $.Values.cloudSqlProxy.privateIp }}
-          - "--private-ip"
-          {{- end }}
-          {{- if $.Values.cloudSqlProxy.autoIamAuthn }}
-          - "--auto-iam-authn"
-          {{- end }}
-          - "{{ $.Values.cloudSqlProxy.instanceConnectionName }}"
-          {{- range $.Values.cloudSqlProxy.extraArgs }}
-          - {{ . | quote }}
-          {{- end }}
-        {{- with $.Values.cloudSqlProxy.resources }}
-        resources:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        securityContext:
-          runAsNonRoot: true
-          allowPrivilegeEscalation: false
+      {{- if and $.Values.cloudSqlProxy.enabled $.Values.cloudSqlProxy.initContainer }}
+      - {{- toYaml $.Values.cloudSqlProxy.initContainer | nindent 8 }}
       {{- end }}
       - name: extract-schema-versions
         {{- $globalImage := $.Values.global.image | default dict }}
@@ -821,6 +799,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       containers:
+      {{- if and $.Values.cloudSqlProxy.enabled $.Values.cloudSqlProxy.container }}
+      - {{- toYaml $.Values.cloudSqlProxy.container | nindent 8 }}
+      {{- end }}
       - name: cadence-{{ $serviceName }}
         {{- $globalImage := $.Values.global.image | default dict }}
         {{- $serviceImage := $service.image | default dict }}

--- a/charts/cadence/templates/server-deployment.yaml
+++ b/charts/cadence/templates/server-deployment.yaml
@@ -78,6 +78,31 @@ spec:
         {{- toYaml $serviceTopologySpreadConstraints | nindent 8 }}
       {{- end }}
       initContainers:
+      {{- if and $.Values.cloudSqlProxy.enabled (or (eq $.Values.config.persistence.database.driver "postgres") (eq $.Values.config.persistence.database.driver "mysql")) }}
+      - name: cloud-sql-proxy
+        restartPolicy: Always
+        image: {{ $.Values.cloudSqlProxy.image.repository }}:{{ $.Values.cloudSqlProxy.image.tag }}
+        imagePullPolicy: {{ $.Values.cloudSqlProxy.image.pullPolicy }}
+        args:
+          - "--port={{ $.Values.cloudSqlProxy.port }}"
+          {{- if $.Values.cloudSqlProxy.privateIp }}
+          - "--private-ip"
+          {{- end }}
+          {{- if $.Values.cloudSqlProxy.autoIamAuthn }}
+          - "--auto-iam-authn"
+          {{- end }}
+          - "{{ $.Values.cloudSqlProxy.instanceConnectionName }}"
+          {{- range $.Values.cloudSqlProxy.extraArgs }}
+          - {{ . | quote }}
+          {{- end }}
+        {{- with $.Values.cloudSqlProxy.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+      {{- end }}
       - name: extract-schema-versions
         {{- $globalImage := $.Values.global.image | default dict }}
         {{- $serviceImage := $service.image | default dict }}
@@ -381,11 +406,13 @@ spec:
         - name: DB_USER
           value: {{ $.Values.config.persistence.database.sql.user | quote }}
         # Authentication parameters
+        {{- if $.Values.config.persistence.database.sql.password }}
         - name: POSTGRES_PWD
           valueFrom:
             secretKeyRef:
               name: {{ include "cadence.fullname" $ }}-{{ $serviceName }}-secrets
               key: POSTGRES_PWD
+        {{- end }}
         # TLS Configuration
         - name: TLS_ENABLED
           value: {{ $.Values.config.persistence.database.sql.tls.enabled | quote }}
@@ -519,11 +546,13 @@ spec:
         - name: DB_USER
           value: {{ $.Values.config.persistence.database.sql.user | quote }}
         # Authentication parameters
+        {{- if $.Values.config.persistence.database.sql.password }}
         - name: MYSQL_PWD
           valueFrom:
             secretKeyRef:
               name: {{ include "cadence.fullname" $ }}-{{ $serviceName }}-secrets
               key: MYSQL_PWD
+        {{- end }}
         # TLS Configuration
         - name: TLS_ENABLED
           value: {{ $.Values.config.persistence.database.sql.tls.enabled | quote }}

--- a/charts/cadence/values.yaml
+++ b/charts/cadence/values.yaml
@@ -574,33 +574,58 @@ serviceAccount:
   automountServiceAccountToken: true
 
 # Cloud SQL Proxy configuration
+# Generic configuration for database proxy containers (Cloud SQL Proxy, Azure DB Proxy, etc.)
+# The template will add these containers as-is to server deployments and schema jobs
 cloudSqlProxy:
-  # -- Enable Cloud SQL Proxy sidecar container
+  # -- Enable database proxy containers
   enabled: false
-  # -- Cloud SQL Proxy image
-  image:
-    repository: gcr.io/cloud-sql-connectors/cloud-sql-proxy
-    tag: "2.14.1"
-    pullPolicy: IfNotPresent
-  # -- Cloud SQL instance connection name (format: project:region:instance)
-  instanceConnectionName: ""
-  # -- Port for Cloud SQL Proxy to listen on
-  port: 5432
-  # -- Use private IP for Cloud SQL instance connection (requires VPC peering)
-  privateIp: false
-  # -- Enable automatic IAM authentication (requires proper IAM permissions, no database password needed)
-  autoIamAuthn: false
-  # -- Additional command-line arguments for cloud-sql-proxy
-  # Example: ["--max-connections=100", "--max-sigterm-delay=30s"]
-  extraArgs: []
-  # -- Resource limits and requests for the proxy sidecar
-  resources:
-    requests:
-      cpu: 100m
-      memory: 128Mi
-    limits:
-      cpu: 200m
-      memory: 256Mi
+
+  # -- Init container specification (runs as native sidecar with restartPolicy: Always)
+  # Uncomment and configure to add a database proxy init container
+  initContainer: {}
+    # Example: Cloud SQL Proxy for Google Cloud
+    # name: cloud-sql-proxy
+    # restartPolicy: Always  # Required for native sidecar pattern (K8s 1.29+)
+    # image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1
+    # imagePullPolicy: IfNotPresent
+    # args:
+    #   - "PROJECT:REGION:INSTANCE"  # Replace with your instance connection name
+    #   - "--port=3306"
+    #   - "--private-ip"  # Optional: use private IP (requires VPC peering)
+    #   - "--auto-iam-authn"  # Optional: enable IAM authentication
+    # resources:
+    #   requests:
+    #     cpu: 100m
+    #     memory: 128Mi
+    #   limits:
+    #     cpu: 200m
+    #     memory: 256Mi
+    # securityContext:
+    #   runAsNonRoot: true
+    #   allowPrivilegeEscalation: false
+
+  # -- Regular sidecar container specification
+  # Uncomment and configure to add a database proxy as a regular container
+  container: {}
+    # Example: Cloud SQL Proxy for Google Cloud (if you're using Cloud Service Mesh or Istio)
+    # name: cloud-sql-proxy
+    # image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1
+    # imagePullPolicy: IfNotPresent
+    # args:
+    #   - "PROJECT:REGION:INSTANCE"  # Replace with your instance connection name
+    #   - "--port=3306"
+    #   - "--private-ip"  # Optional: use private IP (requires VPC peering)
+    #   - "--auto-iam-authn"  # Optional: enable IAM authentication
+    # resources:
+    #   requests:
+    #     cpu: 100m
+    #     memory: 128Mi
+    #   limits:
+    #     cpu: 200m
+    #     memory: 256Mi
+    # securityContext:
+    #   runAsNonRoot: true
+    #   allowPrivilegeEscalation: false
 
 # RBAC configuration
 rbac:

--- a/charts/cadence/values.yaml
+++ b/charts/cadence/values.yaml
@@ -573,6 +573,35 @@ serviceAccount:
   # -- Automatically mount service account token
   automountServiceAccountToken: true
 
+# Cloud SQL Proxy configuration
+cloudSqlProxy:
+  # -- Enable Cloud SQL Proxy sidecar container
+  enabled: false
+  # -- Cloud SQL Proxy image
+  image:
+    repository: gcr.io/cloud-sql-connectors/cloud-sql-proxy
+    tag: "2.14.1"
+    pullPolicy: IfNotPresent
+  # -- Cloud SQL instance connection name (format: project:region:instance)
+  instanceConnectionName: ""
+  # -- Port for Cloud SQL Proxy to listen on
+  port: 5432
+  # -- Use private IP for Cloud SQL instance connection (requires VPC peering)
+  privateIp: false
+  # -- Enable automatic IAM authentication (requires proper IAM permissions, no database password needed)
+  autoIamAuthn: false
+  # -- Additional command-line arguments for cloud-sql-proxy
+  # Example: ["--max-connections=100", "--max-sigterm-delay=30s"]
+  extraArgs: []
+  # -- Resource limits and requests for the proxy sidecar
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
 # RBAC configuration
 rbac:
   # -- Enable RBAC creation


### PR DESCRIPTION
<!--
Thank you for contributing to cadence-workflow/cadence-charts.
Before you submit this pull request we'd like to make sure you are aware of our release process and best practices:

* https://github.com/cadence-workflow/cadence-charts/blob/main/CONTRIBUTING.md#release-process
* https://helm.sh/docs/chart_best_practices/
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### Description of this PR
This PR updates the helm chart to support Cadence deployment with Cloud SQL for MySQL as the database store. A helper script and document is introduced to provide guidance on deploying a new Cadence cluster on GKE using Cloud SQL for MySQL.


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] `Chart.yaml`: Chart `version` bumped
- [x] `values.yaml`: `global.image.tag` (should match with `Chart.yaml` appVersion)
- [x] Dependencies in `Chart.yaml` (check for updates with `helm dependency update`, aim for latest major-1 stable)
- [x] [DCO](https://github.com/cadence-workflow/cadence-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Test deployment locally
- [x] Run `helm-docs` to update documentation